### PR TITLE
fix(sync): normalize NATS rel_path + fix cross-host state cache lookup

### DIFF
--- a/crates/tcfs-sync/src/state.rs
+++ b/crates/tcfs-sync/src/state.rs
@@ -127,13 +127,27 @@ impl StateCache {
         self.entries.is_empty()
     }
 
-    /// Find a state entry by its remote path suffix (for NATS event lookups).
+    /// Find a state entry by relative path (for NATS auto-pull lookups).
+    ///
+    /// Searches cache keys (canonical local paths) by suffix match, then
+    /// falls back to remote_path matching. Cache keys are absolute paths
+    /// like `/home/jess/tcfs/dir/file.txt` — matching the suffix against
+    /// the normalized rel_path (`dir/file.txt`) handles cross-host home
+    /// directory differences.
     pub fn get_by_rel_path(&self, rel_path: &str) -> Option<(&str, &SyncState)> {
+        let normalized = rel_path.trim_start_matches('/');
+        // Primary: match cache keys (canonical local paths) by suffix
         self.entries
             .iter()
-            .find(|(_, state)| {
-                state.remote_path.ends_with(&format!("/{}", rel_path))
-                    || state.remote_path == rel_path
+            .find(|(key, _)| {
+                key.ends_with(&format!("/{}", normalized)) || *key == normalized
+            })
+            // Fallback: match remote_path (manifest path) for backward compat
+            .or_else(|| {
+                self.entries.iter().find(|(_, state)| {
+                    state.remote_path.ends_with(&format!("/{}", normalized))
+                        || state.remote_path == normalized
+                })
             })
             .map(|(k, v)| (k.as_str(), v))
     }

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -5,7 +5,7 @@ use secrecy::ExposeSecret;
 use std::sync::Arc;
 use tcfs_core::config::TcfsConfig;
 use tcfs_sync::conflict::ConflictResolver;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use tcfs_crypto::MasterKey;
 
@@ -1084,6 +1084,11 @@ async fn do_auto_download(
                         },
                     );
                     let _ = cache.flush();
+                    debug!(
+                        key = %local_path.display(),
+                        hash = %manifest.file_hash,
+                        "auto-pull: state cache updated with remote metadata"
+                    );
                 }
                 Err(e) => {
                     warn!(

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -386,7 +386,11 @@ impl TcfsDaemon for TcfsDaemonImpl {
                       vclock: &tcfs_sync::conflict::VectorClock| {
                     let nats = nats_handle.clone();
                     let device = flush_device_id.clone();
-                    let path = vpath.to_string();
+                    // Strip leading '/' from FUSE virtual path to produce a
+                    // relative path matching the S3 index key format. Without
+                    // this, receiving hosts get `/file.txt` instead of `file.txt`
+                    // and sync_root.join() produces malformed local paths.
+                    let path = vpath.trim_start_matches('/').to_string();
                     let hash = hash.to_string();
                     let vclock = vclock.clone();
                     let pfx = flush_prefix.clone();


### PR DESCRIPTION
## Summary
- Strip leading `/` from FUSE vpath before NATS publish (grpc.rs) — was sending raw vpaths like `/dir/file` instead of `dir/file`
- Fix `get_by_rel_path()` to search cache keys by suffix instead of manifest paths (state.rs) — old code searched `tcfs/manifests/{hash}` which never matches a file path
- Add debug logging after state cache update for field diagnosis (daemon.rs)

## Root Cause
Cross-host TCFS sync (push from neo/macOS, pull on honey/Linux) fails because:
1. NATS `FileSynced` event carries FUSE vpath with leading `/` → `sync_root.join("/file")` produces wrong local path on receiver
2. `get_by_rel_path()` searched `state.remote_path` (manifest path) instead of cache keys (canonical local paths) → never matched
3. Files were reported as "synced" in daemon logs but never materialized on FUSE mount

## Test Plan
- [x] `cargo check -p tcfsd -p tcfs-sync` — compiles clean
- [x] `cargo test -p tcfs-sync -p tcfsd` — all tests pass (3/3)
- [ ] Cross-host E2E: push from neo, verify on honey FUSE mount
- [ ] Verify NATS `rel_path` no longer starts with `/` (check daemon logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)