### PR TITLE
fix(fuse): NATS-driven negative cache invalidation + shorter dir TTL

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1597,7 +1597,7 @@ async fn cmd_mount(
                     None
                 }
             },
-        })
+        }, None)
         .await
         .context("FUSE mount failed")
     }

--- a/crates/tcfs-fuse/src/driver.rs
+++ b/crates/tcfs-fuse/src/driver.rs
@@ -22,8 +22,12 @@ use tcfs_vfs::{OnFlushCallback, TcfsVfs, VfsAttr, VirtualFilesystem};
 
 // ── Configuration ─────────────────────────────────────────────────────────
 
-/// TTL for positive dentry/attr cache entries (FUSE kernel cache)
+/// TTL for file attribute cache entries (FUSE kernel cache).
 const ATTR_TTL: Duration = Duration::from_secs(5);
+
+/// TTL for directory entry cache. Shorter than ATTR_TTL so that new files
+/// from NATS events appear within ~1s without needing kernel notification.
+const DIR_TTL: Duration = Duration::from_secs(1);
 
 /// Timeout for VFS/S3 operations. Prevents mount from hanging when the
 /// S3 backend is slow or unreachable.
@@ -249,13 +253,20 @@ impl PathFilesystem for TcfsFs {
                     Some(ref a) => to_fuse_attr(a),
                     None => dir_attr,
                 };
+                // Use shorter TTL for directory entries so NATS-synced files
+                // appear within ~1s without kernel invalidation.
+                let ttl = if vfs_entry.kind == VfsFileType::Directory {
+                    DIR_TTL
+                } else {
+                    ATTR_TTL
+                };
                 entries.push(Ok(DirectoryEntryPlus {
                     kind: to_fuse_file_type(vfs_entry.kind),
                     name: vfs_entry.name.into(),
                     offset: next_offset,
                     attr,
-                    entry_ttl: ATTR_TTL,
-                    attr_ttl: ATTR_TTL,
+                    entry_ttl: DIR_TTL,
+                    attr_ttl: ttl,
                 }));
             }
             next_offset += 1;
@@ -514,7 +525,10 @@ pub struct MountConfig {
 ///
 /// Creates a `TcfsVfs` and wraps it with the FUSE `PathFilesystem` adapter.
 /// Uses `mount_with_unprivileged` which invokes `fusermount3` — no root needed.
-pub async fn mount(cfg: MountConfig) -> std::io::Result<()> {
+///
+/// Returns the shared VFS handle via `vfs_out` so the caller can invalidate
+/// the negative cache from the NATS handler when remote files arrive.
+pub async fn mount(cfg: MountConfig, vfs_out: Option<&tokio::sync::watch::Sender<Option<Arc<TcfsVfs>>>>) -> std::io::Result<()> {
     let mut vfs = TcfsVfs::new(
         cfg.op,
         cfg.prefix,
@@ -532,6 +546,11 @@ pub async fn mount(cfg: MountConfig) -> std::io::Result<()> {
     } else {
         Arc::new(vfs)
     };
+
+    // Publish VFS handle so NATS handler can invalidate negative cache
+    if let Some(tx) = vfs_out {
+        let _ = tx.send(Some(vfs.clone()));
+    }
 
     let fs = TcfsFs::new(vfs);
 

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -156,6 +156,18 @@ impl TcfsVfs {
         &self.disk_cache
     }
 
+    /// Invalidate the negative cache for a path, so the next lookup/readdir
+    /// won't return ENOENT from cache. Called by the NATS handler when a
+    /// remote device syncs a new file.
+    pub fn invalidate_path(&self, path: &str) {
+        self.negative_cache.remove(path);
+        // Also invalidate parent directory so readdir picks up the new entry
+        if let Some(parent) = path.rsplit_once('/').map(|(p, _)| p) {
+            let parent = if parent.is_empty() { "/" } else { parent };
+            self.negative_cache.remove(parent);
+        }
+    }
+
     /// Flush modified file content to SeaweedFS (index + manifest + chunks).
     ///
     /// Uses FastCDC content-defined chunking for deduplication. Small files

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -868,6 +868,7 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
                         impl_.state_cache_handle(),
                         sync_root,
                         storage_prefix,
+                        impl_.vfs_handle.clone(),
                     )
                     .await;
 
@@ -1029,6 +1030,7 @@ async fn spawn_state_sync_loop(
     state_cache: Arc<tokio::sync::Mutex<tcfs_sync::state::StateCache>>,
     sync_root: Option<std::path::PathBuf>,
     storage_prefix: String,
+    vfs_handle: tokio::sync::watch::Receiver<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
 ) {
     use futures::StreamExt;
 
@@ -1086,6 +1088,14 @@ async fn spawn_state_sync_loop(
                                                 &storage_prefix,
                                             )
                                             .await;
+
+                                            // Invalidate FUSE negative cache so the
+                                            // new file appears in readdir immediately
+                                            if let Some(ref vfs) = *vfs_handle.borrow() {
+                                                let vpath = format!("/{}", rel_path);
+                                                vfs.invalidate_path(&vpath);
+                                                debug!(path = %vpath, "FUSE negative cache invalidated for remote file");
+                                            }
                                         }
                                         "interactive" => {
                                             info!(

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -33,6 +33,10 @@ pub struct TcfsDaemonImpl {
     nats_ok: std::sync::atomic::AtomicBool,
     nats: Arc<TokioMutex<Option<tcfs_sync::NatsClient>>>,
     active_mounts: Arc<TokioMutex<std::collections::HashMap<String, tokio::process::Child>>>,
+    /// VFS handle from active FUSE mount — used to invalidate negative cache
+    /// on NATS events so remote files appear in readdir immediately.
+    pub vfs_handle: tokio::sync::watch::Receiver<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
+    vfs_tx: tokio::sync::watch::Sender<Option<std::sync::Arc<tcfs_vfs::TcfsVfs>>>,
     // Auth infrastructure
     session_store: tcfs_auth::SessionStore,
     totp_provider: Arc<tcfs_auth::totp::TotpProvider>,
@@ -53,6 +57,8 @@ impl TcfsDaemonImpl {
         device_name: String,
         master_key: Option<tcfs_crypto::MasterKey>,
     ) -> Self {
+        let (vfs_tx, vfs_rx) = tokio::sync::watch::channel(None);
+
         let totp_config = tcfs_auth::totp::TotpConfig {
             issuer: config.auth.totp.issuer.clone(),
             digits: config.auth.totp.digits as usize,
@@ -95,6 +101,8 @@ impl TcfsDaemonImpl {
             nats_ok: std::sync::atomic::AtomicBool::new(false),
             nats: Arc::new(TokioMutex::new(None)),
             active_mounts: Arc::new(TokioMutex::new(std::collections::HashMap::new())),
+            vfs_handle: vfs_rx,
+            vfs_tx,
             session_store: tcfs_auth::SessionStore::new(),
             totp_provider,
             webauthn_provider,
@@ -419,26 +427,32 @@ impl TcfsDaemon for TcfsDaemonImpl {
                 },
             ));
 
+            let vfs_sender = self.vfs_tx.clone();
             let mount_handle = tokio::spawn(async move {
                 tracing::info!("FUSE mount task starting (prefix={prefix})");
-                match tcfs_fuse::mount(tcfs_fuse::MountConfig {
-                    op,
-                    prefix,
-                    mountpoint: mp,
-                    cache_dir: std::path::PathBuf::from(&cache_dir),
-                    cache_max_bytes: cache_max,
-                    negative_ttl_secs: neg_ttl,
-                    read_only: req.read_only,
-                    allow_other: false,
-                    on_flush,
-                    device_id: mount_device_id,
-                    master_key: Some(mount_master_key),
-                })
+                match tcfs_fuse::mount(
+                    tcfs_fuse::MountConfig {
+                        op,
+                        prefix,
+                        mountpoint: mp,
+                        cache_dir: std::path::PathBuf::from(&cache_dir),
+                        cache_max_bytes: cache_max,
+                        negative_ttl_secs: neg_ttl,
+                        read_only: req.read_only,
+                        allow_other: false,
+                        on_flush,
+                        device_id: mount_device_id,
+                        master_key: Some(mount_master_key),
+                    },
+                    Some(&vfs_sender),
+                )
                 .await
                 {
                     Ok(()) => tracing::info!("FUSE mount unmounted cleanly"),
                     Err(e) => tracing::error!(error = %e, "FUSE mount failed"),
                 }
+                // Clear VFS handle on unmount
+                let _ = vfs_sender.send(None);
             });
 
             let mk = mountpoint_key.clone();


### PR DESCRIPTION
## Summary

- **DIR_TTL reduced to 1s** — directory entry kernel cache refreshes within 1s instead of 5s, so NATS-synced files appear quickly without needing fuse3 kernel notify API (which is private)
- **VFS invalidate_path()** — clears negative cache for a path + parent, preventing stale ENOENT for newly synced files
- **VFS handle bridge** — `tokio::watch` channel passes Arc<TcfsVfs> from mount() to daemon NATS handler
- **NATS handler invalidation** — after `handle_auto_pull`, invalidates negative cache so next readdir sees the file

## Architecture

```
NATS FileSynced event
  → spawn_state_sync_loop
    → handle_auto_pull (updates state cache)
    → vfs.invalidate_path("/newfile.txt") (clears negative cache)
    → kernel DIR_TTL expires (1s)
    → next readdir queries S3 index → sees new file
```

## Test plan

- [ ] All 120+ workspace tests pass
- [ ] Mount FUSE, push file from another device via NATS
- [ ] `ls ~/tcfs/` within 1-2s shows new file (was 5s+ before, or never if negative-cached)

Closes #4