### PR TITLE
feat(nix): .app bundle derivation + home-manager launchd wiring

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,10 +127,32 @@
           '';
         });
 
+        # macOS .app bundle for TCC persistence.
+        # TCC grants (Full Disk Access, etc.) are tied to bundle ID + CDHash.
+        # Bare binaries in /nix/store/ lose grants on every rebuild.
+        # This bundle provides a stable identity (io.tinyland.tcfsd).
+        tcfsd-app = pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin (
+          pkgs.stdenv.mkDerivation {
+            pname = "tcfsd-app";
+            version = tcfsd.version or "0.12.0";
+            dontUnpack = true;
+            buildInputs = [ pkgs.darwin.sigtool ];
+            installPhase = ''
+              mkdir -p $out/Applications/TCFSDaemon.app/Contents/MacOS
+              cp ${tcfsd}/bin/tcfsd $out/Applications/TCFSDaemon.app/Contents/MacOS/tcfsd
+              cp ${./swift/daemon/resources/Info.plist} $out/Applications/TCFSDaemon.app/Contents/Info.plist
+              # Ad-hoc sign for local use; Developer ID signing done out-of-band
+              codesign -f -s - --options runtime $out/Applications/TCFSDaemon.app || true
+            '';
+          }
+        );
+
       in {
         packages = {
           default = tcfsd;
           inherit tcfsd tcfs-cli tcfs-tui tcfs-mcp tcfs-file-provider-staticlib;
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
+          inherit tcfsd-app;
         };
 
         devShells.default = pkgs.mkShell {

--- a/nix/modules/tcfs-user.nix
+++ b/nix/modules/tcfs-user.nix
@@ -115,6 +115,30 @@ in {
       description = "Glob patterns for files/dirs to exclude from sync";
     };
 
+    # ── macOS TCC persistence (.app bundle) ──────────────────────────────
+    useAppBundle = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Use TCFSDaemon.app bundle for launchd instead of the bare Nix store binary.
+        TCC grants (Full Disk Access, etc.) are tied to bundle ID + CDHash.
+        Bare /nix/store/ binaries lose grants on every rebuild.
+        The .app bundle provides a stable identity (io.tinyland.tcfsd).
+      '';
+    };
+
+    appBundlePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/Applications/TCFSDaemon.app";
+      description = "Path to installed TCFSDaemon.app bundle (used when useAppBundle is true)";
+    };
+
+    appBundlePackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "tcfsd-app package derivation (builds the .app bundle from Nix)";
+    };
+
     remoteJuggler = {
       enable = lib.mkEnableOption "RemoteJuggler integration for credential management";
 
@@ -178,7 +202,11 @@ in {
     launchd.agents.tcfsd = lib.mkIf pkgs.stdenv.isDarwin {
       enable = true;
       config = {
-        ProgramArguments = [ "${cfg.package}/bin/tcfsd" "--mode" "daemon" ];
+        ProgramArguments = let
+          executable = if cfg.useAppBundle
+            then "${cfg.appBundlePath}/Contents/MacOS/tcfsd"
+            else "${cfg.package}/bin/tcfsd";
+        in [ executable "--mode" "daemon" ];
         RunAtLoad = true;
         KeepAlive = true;
         StandardOutPath = "/tmp/tcfsd.stdout.log";
@@ -188,5 +216,18 @@ in {
         };
       };
     };
+
+    # ── macOS: install .app bundle to /Applications/ ────────────────────
+    home.activation.tcfsd-app-bundle = lib.mkIf (pkgs.stdenv.isDarwin && cfg.useAppBundle && cfg.appBundlePackage != null)
+      (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        if [ -d "${cfg.appBundlePackage}/Applications/TCFSDaemon.app" ]; then
+          $DRY_RUN_CMD rm -rf "${cfg.appBundlePath}"
+          $DRY_RUN_CMD cp -RL "${cfg.appBundlePackage}/Applications/TCFSDaemon.app" "${cfg.appBundlePath}"
+          $DRY_RUN_CMD chmod -R u+w "${cfg.appBundlePath}"
+          # Re-sign after copy (Nix store copy invalidates ad-hoc signature)
+          $DRY_RUN_CMD codesign -f -s - --options runtime "${cfg.appBundlePath}" || true
+          $VERBOSE_ECHO "Installed TCFSDaemon.app to ${cfg.appBundlePath}"
+        fi
+      '');
   };
 }


### PR DESCRIPTION
## Summary
- Adds `tcfsd-app` Nix derivation (macOS-only) that wraps `tcfsd` binary in `TCFSDaemon.app` for TCC persistence
- macOS Sequoia TCC grants are tied to bundle ID + CDHash — bare `/nix/store/` binaries lose grants on every rebuild
- Adds `useAppBundle`, `appBundlePath`, `appBundlePackage` options to home-manager module
- `home.activation` hook auto-installs and re-signs the bundle on every `home-manager switch`
- Launchd ProgramArguments automatically points to `/Applications/TCFSDaemon.app/Contents/MacOS/tcfsd` when enabled

### Usage
```nix
programs.tcfs = {
  enable = true;
  useAppBundle = true;
  appBundlePackage = inputs.tummycrypt.packages.${pkgs.system}.tcfsd-app;
  # ... other settings
};
```

## Test plan
- [x] `nix eval .#packages.aarch64-darwin` — `tcfsd-app` appears in package list
- [x] Nix module syntax validates (returns lambda)
- [ ] `nix build .#tcfsd-app` — produces TCFSDaemon.app in /nix/store
- [ ] `home-manager switch` installs bundle to /Applications/ and launchd references it
- [ ] TCC grants survive `home-manager switch` (verify in System Settings > Privacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)