### PR TITLE
fix(sync): sync empty directories via .tcfs_dir markers

### DIFF
--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -746,6 +746,7 @@ fn collect_config_from_sync(
         sync_hidden_dirs: config.sync.sync_hidden_dirs,
         exclude_patterns: config.sync.exclude_patterns.clone(),
         follow_symlinks: false,
+        sync_empty_dirs: config.sync.sync_empty_dirs,
     }
 }
 

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -230,6 +230,9 @@ pub struct SyncConfig {
     pub sync_hidden_dirs: bool,
     /// Glob patterns to exclude from sync
     pub exclude_patterns: Vec<String>,
+    /// Whether to sync empty directories via `.tcfs_dir` markers.
+    /// Default: true.
+    pub sync_empty_dirs: bool,
     /// Local directory root for synced files (used by auto-pull)
     pub sync_root: Option<PathBuf>,
     /// Maximum file age (seconds) before eligible for auto-unsync.
@@ -391,6 +394,7 @@ impl Default for SyncConfig {
             git_sync_mode: "bundle".into(),
             sync_hidden_dirs: false,
             exclude_patterns: Vec::new(),
+            sync_empty_dirs: true,
             sync_root: None,
             auto_unsync_max_age_secs: 0,
             auto_unsync_interval_secs: 3600,

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -53,6 +53,8 @@ pub struct CollectConfig {
     pub exclude_patterns: Vec<String>,
     /// Whether to follow symlinks (default: false — skip with warning)
     pub follow_symlinks: bool,
+    /// Whether to sync empty directories via `.tcfs_dir` markers
+    pub sync_empty_dirs: bool,
 }
 
 impl Default for CollectConfig {
@@ -63,8 +65,18 @@ impl Default for CollectConfig {
             sync_hidden_dirs: false,
             exclude_patterns: Vec::new(),
             follow_symlinks: false,
+            sync_empty_dirs: true,
         }
     }
+}
+
+/// Result of collecting files and empty directories from a local tree.
+#[derive(Debug, Clone)]
+pub struct CollectResult {
+    /// Regular files to upload.
+    pub files: Vec<PathBuf>,
+    /// Empty directories (no files after exclusions) to create markers for.
+    pub empty_dirs: Vec<PathBuf>,
 }
 
 /// Result of uploading a single file
@@ -869,10 +881,10 @@ pub async fn push_tree_with_device(
     let mut bytes = 0u64;
 
     let cfg = collect_cfg.cloned().unwrap_or_default();
-    let files = collect_files(local_root, &cfg)?;
-    let total = files.len();
+    let result = collect_files(local_root, &cfg)?;
+    let total = result.files.len();
 
-    for (i, path) in files.iter().enumerate() {
+    for (i, path) in result.files.iter().enumerate() {
         let rel = path.strip_prefix(local_root).unwrap_or(path);
         let rel_str = rel.to_string_lossy().replace('\\', "/");
 
@@ -920,6 +932,29 @@ pub async fn push_tree_with_device(
         }
     }
 
+    // Write `.tcfs_dir` markers for empty directories
+    for dir in &result.empty_dirs {
+        // Skip the root itself — it's never "empty" in the sync sense
+        if dir == local_root {
+            continue;
+        }
+        if let Ok(rel) = dir.strip_prefix(local_root) {
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let marker_key = format!(
+                "{}/index/{}/.tcfs_dir",
+                remote_path_prefix(remote_prefix),
+                rel_str
+            );
+            let marker_content = b"type=directory\n";
+            if let Err(e) = op.write(&marker_key, marker_content.to_vec()).await {
+                warn!(dir = %dir.display(), "failed to write empty dir marker: {e}");
+            } else {
+                debug!(dir = %rel_str, "wrote empty directory marker");
+                uploaded += 1;
+            }
+        }
+    }
+
     // Flush state cache after tree push
     state.flush()?;
 
@@ -927,8 +962,13 @@ pub async fn push_tree_with_device(
 }
 
 /// Collect all regular files under `root` recursively, respecting config.
-pub fn collect_files(root: &Path, config: &CollectConfig) -> Result<Vec<PathBuf>> {
+///
+/// When `config.sync_empty_dirs` is true, also collects directories that
+/// contain no files (after exclusion rules) so callers can create `.tcfs_dir`
+/// marker objects in the remote index.
+pub fn collect_files(root: &Path, config: &CollectConfig) -> Result<CollectResult> {
     let mut files = Vec::new();
+    let mut empty_dirs = Vec::new();
     let exclude_matchers: Vec<glob::Pattern> = config
         .exclude_patterns
         .iter()
@@ -939,18 +979,29 @@ pub fn collect_files(root: &Path, config: &CollectConfig) -> Result<Vec<PathBuf>
     if let Ok(canon) = std::fs::canonicalize(root) {
         visited.insert(canon);
     }
-    collect_files_inner(root, &mut files, config, &exclude_matchers, &mut visited)?;
+    collect_files_inner(
+        root,
+        &mut files,
+        &mut empty_dirs,
+        config,
+        &exclude_matchers,
+        &mut visited,
+    )?;
     files.sort(); // deterministic order
-    Ok(files)
+    empty_dirs.sort();
+    Ok(CollectResult { files, empty_dirs })
 }
 
 fn collect_files_inner(
     dir: &Path,
     out: &mut Vec<PathBuf>,
+    empty_dirs: &mut Vec<PathBuf>,
     config: &CollectConfig,
     excludes: &[glob::Pattern],
     visited: &mut std::collections::HashSet<PathBuf>,
 ) -> Result<()> {
+    let before = out.len();
+
     for entry in
         std::fs::read_dir(dir).with_context(|| format!("reading dir: {}", dir.display()))?
     {
@@ -992,7 +1043,9 @@ fn collect_files_inner(
                         // Check what the resolved target actually is
                         match std::fs::metadata(&real) {
                             Ok(meta) if meta.is_dir() => {
-                                collect_files_inner(&path, out, config, excludes, visited)?;
+                                collect_files_inner(
+                                    &path, out, empty_dirs, config, excludes, visited,
+                                )?;
                             }
                             Ok(meta) if meta.is_file() => {
                                 out.push(path);
@@ -1053,7 +1106,7 @@ fn collect_files_inner(
                             continue;
                         }
                         // In raw mode, recurse into .git
-                        collect_files_inner(&path, out, config, excludes, visited)?;
+                        collect_files_inner(&path, out, empty_dirs, config, excludes, visited)?;
                     }
                     continue;
                 }
@@ -1063,12 +1116,19 @@ fn collect_files_inner(
                     continue;
                 }
 
-                collect_files_inner(&path, out, config, excludes, visited)?;
+                collect_files_inner(&path, out, empty_dirs, config, excludes, visited)?;
             } else if ft.is_file() {
                 out.push(path);
             }
         }
     }
+
+    // If no files were collected from this directory (directly or via
+    // subdirectories) and we're tracking empty dirs, record it as empty.
+    if config.sync_empty_dirs && out.len() == before {
+        empty_dirs.push(dir.to_path_buf());
+    }
+
     Ok(())
 }
 
@@ -1235,4 +1295,134 @@ pub async fn delete_remote_file(
 /// Normalize a remote prefix: ensure it doesn't have trailing slash
 fn remote_path_prefix(prefix: &str) -> String {
     prefix.trim_end_matches('/').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> CollectConfig {
+        CollectConfig::default()
+    }
+
+    fn no_empty_dirs_config() -> CollectConfig {
+        CollectConfig {
+            sync_empty_dirs: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn collect_finds_empty_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create structure: root/a/file.txt, root/empty/, root/nested/also_empty/
+        std::fs::create_dir_all(root.join("a")).unwrap();
+        std::fs::write(root.join("a/file.txt"), b"content").unwrap();
+        std::fs::create_dir_all(root.join("empty")).unwrap();
+        std::fs::create_dir_all(root.join("nested/also_empty")).unwrap();
+
+        let result = collect_files(root, &default_config()).unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("a/file.txt"));
+
+        // empty/ and nested/also_empty/ should be detected as empty dirs
+        // nested/ itself also has no files (its only child is also_empty/ which is empty)
+        let empty_names: Vec<String> = result
+            .empty_dirs
+            .iter()
+            .map(|d| d.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            empty_names.contains(&"empty".to_string()),
+            "should detect empty/ as empty dir, got: {:?}",
+            empty_names
+        );
+        assert!(
+            empty_names.contains(&"nested/also_empty".to_string()),
+            "should detect nested/also_empty/ as empty dir, got: {:?}",
+            empty_names
+        );
+    }
+
+    #[test]
+    fn collect_skips_empty_dirs_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        std::fs::create_dir_all(root.join("empty")).unwrap();
+        std::fs::write(root.join("file.txt"), b"data").unwrap();
+
+        let result = collect_files(root, &no_empty_dirs_config()).unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        assert!(
+            result.empty_dirs.is_empty(),
+            "empty_dirs should be empty when sync_empty_dirs=false"
+        );
+    }
+
+    #[test]
+    fn collect_dir_with_file_not_marked_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        std::fs::create_dir_all(root.join("has_file")).unwrap();
+        std::fs::write(root.join("has_file/doc.txt"), b"hello").unwrap();
+
+        let result = collect_files(root, &default_config()).unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        // has_file/ contains a file, so it should NOT appear in empty_dirs
+        assert!(
+            !result.empty_dirs.iter().any(|d| d.ends_with("has_file")),
+            "directory with files should not be in empty_dirs"
+        );
+    }
+
+    #[test]
+    fn collect_root_not_marked_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Completely empty root
+        let result = collect_files(root, &default_config()).unwrap();
+
+        assert!(result.files.is_empty());
+        // Root itself should be in empty_dirs (it's empty), but push_tree
+        // skips it. The collector doesn't special-case root.
+        // Actually root IS recorded — push_tree_with_device skips it.
+    }
+
+    #[test]
+    fn collect_excluded_dir_not_counted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create structure: root/target/ (excluded by hardcoded rule)
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::create_dir_all(root.join("real_empty")).unwrap();
+        std::fs::write(root.join("file.txt"), b"data").unwrap();
+
+        let result = collect_files(root, &default_config()).unwrap();
+
+        let empty_names: Vec<String> = result
+            .empty_dirs
+            .iter()
+            .map(|d| d.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+
+        // target/ is excluded entirely, so it shouldn't appear
+        assert!(
+            !empty_names.contains(&"target".to_string()),
+            "excluded dirs should not appear in empty_dirs"
+        );
+        // real_empty/ should appear
+        assert!(
+            empty_names.contains(&"real_empty".to_string()),
+            "real empty dir should be detected"
+        );
+    }
 }

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -659,11 +659,12 @@ fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap
         sync_hidden_dirs: blacklist.allows_hidden_dirs(),
         exclude_patterns: blacklist.glob_patterns(),
         follow_symlinks: false,
+        sync_empty_dirs: false, // reconcile only cares about files
     };
-    let files = crate::engine::collect_files(local_root, &config)?;
+    let result = crate::engine::collect_files(local_root, &config)?;
 
     let mut map = HashMap::new();
-    for file in files {
+    for file in result.files {
         if let Ok(rel) = file.strip_prefix(local_root) {
             let rel_str = rel.to_string_lossy().replace('\\', "/");
             map.insert(rel_str, file);

--- a/crates/tcfs-sync/tests/symlink_handling_test.rs
+++ b/crates/tcfs-sync/tests/symlink_handling_test.rs
@@ -43,14 +43,19 @@ fn symlink_to_file_skipped_when_follow_false() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_file(root.join("real.txt"), root.join("link.txt")).unwrap();
 
-    let files = collect_files(root, &config_no_follow()).unwrap();
+    let result = collect_files(root, &config_no_follow()).unwrap();
 
     // Should only contain real.txt, not link.txt
-    assert_eq!(files.len(), 1, "should skip symlink, got: {:?}", files);
+    assert_eq!(
+        result.files.len(),
+        1,
+        "should skip symlink, got: {:?}",
+        result.files
+    );
     assert!(
-        files[0].ends_with("real.txt"),
+        result.files[0].ends_with("real.txt"),
         "should contain real.txt, got: {:?}",
-        files
+        result.files
     );
 }
 
@@ -65,11 +70,17 @@ fn symlink_to_file_included_when_follow_true() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_file(root.join("real.txt"), root.join("link.txt")).unwrap();
 
-    let files = collect_files(root, &config_follow()).unwrap();
+    let result = collect_files(root, &config_follow()).unwrap();
 
     // Should contain both real.txt and link.txt
-    assert_eq!(files.len(), 2, "should follow symlink, got: {:?}", files);
-    let names: Vec<String> = files
+    assert_eq!(
+        result.files.len(),
+        2,
+        "should follow symlink, got: {:?}",
+        result.files
+    );
+    let names: Vec<String> = result
+        .files
         .iter()
         .map(|f| f.file_name().unwrap().to_string_lossy().to_string())
         .collect();
@@ -89,10 +100,15 @@ fn symlink_to_dir_skipped_when_follow_false() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_dir(root.join("subdir"), root.join("link_dir")).unwrap();
 
-    let files = collect_files(root, &config_no_follow()).unwrap();
+    let result = collect_files(root, &config_no_follow()).unwrap();
 
     // Should only find inner.txt via subdir, not link_dir
-    assert_eq!(files.len(), 1, "should skip dir symlink, got: {:?}", files);
+    assert_eq!(
+        result.files.len(),
+        1,
+        "should skip dir symlink, got: {:?}",
+        result.files
+    );
 }
 
 #[test]
@@ -107,7 +123,7 @@ fn symlink_to_dir_followed_when_follow_true() {
     #[cfg(windows)]
     std::os::windows::fs::symlink_dir(root.join("subdir"), root.join("link_dir")).unwrap();
 
-    let files = collect_files(root, &config_follow()).unwrap();
+    let result = collect_files(root, &config_follow()).unwrap();
 
     // Should find inner.txt via both subdir and link_dir, but cycle detection
     // means the symlink target (subdir) is already visited, so link_dir is skipped
@@ -115,10 +131,10 @@ fn symlink_to_dir_followed_when_follow_true() {
     // from the real dir walk, then link_dir → subdir is detected as a cycle.
     // So we get 1 file, not 2.
     assert_eq!(
-        files.len(),
+        result.files.len(),
         1,
         "cycle detection should prevent re-traversal, got: {:?}",
-        files
+        result.files
     );
 }
 
@@ -132,14 +148,14 @@ fn broken_symlink_skipped_gracefully() {
     // Create a symlink to a non-existent target
     std::os::unix::fs::symlink("/nonexistent/path/to/nowhere", root.join("broken.txt")).unwrap();
 
-    let files = collect_files(root, &config_no_follow()).unwrap();
-    assert_eq!(files.len(), 1, "broken symlink should be skipped");
-    assert!(files[0].ends_with("real.txt"));
+    let result = collect_files(root, &config_no_follow()).unwrap();
+    assert_eq!(result.files.len(), 1, "broken symlink should be skipped");
+    assert!(result.files[0].ends_with("real.txt"));
 
     // Also test with follow=true — should still skip (broken target)
-    let files = collect_files(root, &config_follow()).unwrap();
+    let result = collect_files(root, &config_follow()).unwrap();
     assert_eq!(
-        files.len(),
+        result.files.len(),
         1,
         "broken symlink should be skipped even with follow=true"
     );
@@ -159,14 +175,14 @@ fn circular_symlink_detected() {
     std::os::unix::fs::symlink(root.join("a"), root.join("b/link")).unwrap();
 
     // With follow=true, should detect the cycle and not infinite loop
-    let files = collect_files(root, &config_follow()).unwrap();
+    let result = collect_files(root, &config_follow()).unwrap();
     // Should find real.txt without getting stuck
     assert!(
-        !files.is_empty(),
+        !result.files.is_empty(),
         "should find at least real.txt despite circular symlinks"
     );
     assert!(
-        files.iter().any(|f| f.ends_with("real.txt")),
+        result.files.iter().any(|f| f.ends_with("real.txt")),
         "should still find real.txt"
     );
 }


### PR DESCRIPTION
Superseded by Jesssullivan/tummycrypt PR (rebased onto correct upstream)