### PR TITLE
test(sync): add 28 unit tests for engine, NATS, reconcile

### DIFF
--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1236,3 +1236,181 @@ pub async fn delete_remote_file(
 fn remote_path_prefix(prefix: &str) -> String {
     prefix.trim_end_matches('/').to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal::services::Memory;
+
+    fn memory_op() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    // ── normalize_rel_path ───────────────────────────────────────────────
+
+    #[test]
+    fn normalize_rel_path_relative_passthrough() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("doc.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        // With sync_root set, file under root → relative
+        let result = normalize_rel_path(&file, Some(dir.path()));
+        assert_eq!(result, "doc.txt");
+    }
+
+    #[test]
+    fn normalize_rel_path_nested() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        let file = dir.path().join("a/b/deep.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        let result = normalize_rel_path(&file, Some(dir.path()));
+        assert_eq!(result, "a/b/deep.txt");
+    }
+
+    #[test]
+    fn normalize_rel_path_no_sync_root_strips_leading_slash() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        std::fs::write(&file, b"x").unwrap();
+
+        let result = normalize_rel_path(&file, None);
+        // Absolute path should have leading / stripped
+        assert!(!result.starts_with('/'), "should strip leading /: {result}");
+        assert!(result.ends_with("file.txt"));
+    }
+
+    // ── resolve_manifest_path ─────────────────────────────────────────��──
+
+    #[tokio::test]
+    async fn resolve_manifest_passthrough() {
+        let op = memory_op();
+        let result = resolve_manifest_path(&op, "data/manifests/abc123", "data", None)
+            .await
+            .unwrap();
+        assert_eq!(result, "data/manifests/abc123");
+    }
+
+    #[tokio::test]
+    async fn resolve_manifest_from_index() {
+        let op = memory_op();
+        // Write an index entry
+        op.write(
+            "data/index/doc.txt",
+            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_manifest_path(&op, "doc.txt", "data", None)
+            .await
+            .unwrap();
+        assert_eq!(result, "data/manifests/abc123");
+    }
+
+    #[tokio::test]
+    async fn resolve_manifest_missing_errors() {
+        let op = memory_op();
+        let result = resolve_manifest_path(&op, "nonexistent.txt", "data", None).await;
+        assert!(result.is_err());
+    }
+
+    // ── delete_remote_file ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_remote_file_removes_index_and_manifest() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        // Write index and manifest
+        op.write(
+            "data/index/file.txt",
+            b"manifest_hash=abc123\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/manifests/abc123",
+            br#"{"version":2,"file_hash":"abc123","file_size":100,"chunks":[],"vclock":{"clocks":{}},"written_by":"neo","written_at":0}"#.to_vec(),
+        )
+        .await
+        .unwrap();
+
+        delete_remote_file(&op, "file.txt", "data", &mut state, None)
+            .await
+            .unwrap();
+
+        // Both should be gone
+        assert!(op.read("data/index/file.txt").await.is_err());
+        assert!(op.read("data/manifests/abc123").await.is_err());
+    }
+
+    // ── upload + download roundtrip (memory operator) ────────────────────
+
+    #[tokio::test]
+    async fn upload_download_roundtrip_small_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        // Write a small local file
+        let local = dir.path().join("hello.txt");
+        std::fs::write(&local, b"hello world").unwrap();
+
+        // Upload
+        let up = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(!up.skipped);
+        assert_eq!(up.bytes, 11);
+        assert!(!up.hash.is_empty());
+
+        // Download to a different location
+        let dl_path = dir.path().join("downloaded.txt");
+        let dl = download_file(&op, &up.remote_path, &dl_path, "data", None)
+            .await
+            .unwrap();
+        assert_eq!(dl.bytes, 11);
+
+        // Verify content matches
+        let content = std::fs::read_to_string(&dl_path).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[tokio::test]
+    async fn upload_skips_when_already_synced() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("file.txt");
+        std::fs::write(&local, b"content").unwrap();
+
+        // First upload
+        let up1 = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(!up1.skipped);
+
+        // Second upload of same file — should skip (dedup)
+        let up2 = upload_file(&op, &local, "data", &mut state, None)
+            .await
+            .unwrap();
+        assert!(up2.skipped, "second upload of unchanged file should skip");
+    }
+
+    // ── remote_path_prefix ───────────────────────────────────────────────
+
+    #[test]
+    fn remote_path_prefix_strips_trailing_slash() {
+        assert_eq!(remote_path_prefix("data/"), "data");
+        assert_eq!(remote_path_prefix("data"), "data");
+        assert_eq!(remote_path_prefix("a/b/c/"), "a/b/c");
+    }
+}

--- a/crates/tcfs-sync/src/nats.rs
+++ b/crates/tcfs-sync/src/nats.rs
@@ -189,6 +189,236 @@ mod inner {
         }
     }
 
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn sample_vclock() -> VectorClock {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+            vc
+        }
+
+        // ── StateEvent serialization ─────────────────────────────────────
+
+        #[test]
+        fn state_event_file_synced_roundtrip() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "docs/readme.md".into(),
+                blake3: "abc123def456".into(),
+                size: 2048,
+                vclock: sample_vclock(),
+                manifest_path: "data/manifests/abc123def456".into(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+
+            assert_eq!(decoded.device_id(), "neo");
+            assert_eq!(decoded.event_type(), "file_synced");
+            if let StateEvent::FileSynced { rel_path, size, .. } = decoded {
+                assert_eq!(rel_path, "docs/readme.md");
+                assert_eq!(size, 2048);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_file_deleted_roundtrip() {
+            let event = StateEvent::FileDeleted {
+                device_id: "honey".into(),
+                rel_path: "old.txt".into(),
+                vclock: sample_vclock(),
+                timestamp: 1700000001,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.device_id(), "honey");
+            assert_eq!(decoded.event_type(), "file_deleted");
+        }
+
+        #[test]
+        fn state_event_file_renamed_roundtrip() {
+            let event = StateEvent::FileRenamed {
+                device_id: "neo".into(),
+                old_path: "a.txt".into(),
+                new_path: "b.txt".into(),
+                vclock: VectorClock::new(),
+                timestamp: 0,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileRenamed {
+                old_path, new_path, ..
+            } = decoded
+            {
+                assert_eq!(old_path, "a.txt");
+                assert_eq!(new_path, "b.txt");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_online_roundtrip() {
+            let event = StateEvent::DeviceOnline {
+                device_id: "neo".into(),
+                last_seq: 42,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_online");
+            if let StateEvent::DeviceOnline { last_seq, .. } = decoded {
+                assert_eq!(last_seq, 42);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        #[test]
+        fn state_event_device_offline_roundtrip() {
+            let event = StateEvent::DeviceOffline {
+                device_id: "honey".into(),
+                last_seq: 99,
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "device_offline");
+        }
+
+        #[test]
+        fn state_event_conflict_resolved_roundtrip() {
+            let event = StateEvent::ConflictResolved {
+                device_id: "neo".into(),
+                rel_path: "conflict.txt".into(),
+                resolution: "keep_local".into(),
+                merged_vclock: sample_vclock(),
+                timestamp: 1700000000,
+            };
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.event_type(), "conflict_resolved");
+            if let StateEvent::ConflictResolved { resolution, .. } = decoded {
+                assert_eq!(resolution, "keep_local");
+            } else {
+                panic!("wrong variant");
+            }
+        }
+
+        // ── StateEvent subject generation ────────────────────────────────
+
+        #[test]
+        fn state_event_subject_format() {
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: VectorClock::new(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+            assert_eq!(event.subject(), "STATE.neo.file_synced");
+
+            let event2 = StateEvent::DeviceOnline {
+                device_id: "honey".into(),
+                last_seq: 0,
+                timestamp: 0,
+            };
+            assert_eq!(event2.subject(), "STATE.honey.device_online");
+        }
+
+        // ── SyncTask serialization ───────────────────────────────────────
+
+        #[test]
+        fn sync_task_push_roundtrip() {
+            let task = SyncTask::Push {
+                task_id: "task-001".into(),
+                local_path: "/home/jess/tcfs".into(),
+                remote_prefix: "data".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-001");
+            assert_eq!(decoded.type_name(), "push");
+        }
+
+        #[test]
+        fn sync_task_pull_roundtrip() {
+            let task = SyncTask::Pull {
+                task_id: "task-002".into(),
+                manifest_path: "data/manifests/abc123".into(),
+                remote_prefix: "data".into(),
+                local_path: "/tmp/out.txt".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-002");
+            assert_eq!(decoded.type_name(), "pull");
+        }
+
+        #[test]
+        fn sync_task_unsync_roundtrip() {
+            let task = SyncTask::Unsync {
+                task_id: "task-003".into(),
+                local_path: "/home/jess/tcfs/big.bin".into(),
+            };
+            let bytes = task.to_bytes().unwrap();
+            let decoded = SyncTask::from_bytes(&bytes).unwrap();
+            assert_eq!(decoded.task_id(), "task-003");
+            assert_eq!(decoded.type_name(), "unsync");
+        }
+
+        #[test]
+        fn state_event_invalid_json_errors() {
+            let result = StateEvent::from_bytes(b"not json at all");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn sync_task_invalid_json_errors() {
+            let result = SyncTask::from_bytes(b"{\"type\":\"unknown\"}");
+            assert!(result.is_err());
+        }
+
+        // ── VectorClock survives JSON roundtrip ──────────────────────────
+
+        #[test]
+        fn vclock_preserved_through_state_event() {
+            let mut vc = VectorClock::new();
+            vc.tick("neo");
+            vc.tick("neo");
+            vc.tick("honey");
+
+            let event = StateEvent::FileSynced {
+                device_id: "neo".into(),
+                rel_path: "f.txt".into(),
+                blake3: "x".into(),
+                size: 0,
+                vclock: vc.clone(),
+                manifest_path: "m".into(),
+                timestamp: 0,
+            };
+
+            let bytes = event.to_bytes().unwrap();
+            let decoded = StateEvent::from_bytes(&bytes).unwrap();
+            if let StateEvent::FileSynced { vclock, .. } = decoded {
+                assert_eq!(vclock.get("neo"), 2);
+                assert_eq!(vclock.get("honey"), 1);
+            } else {
+                panic!("wrong variant");
+            }
+        }
+    }
+
     // ── NatsClient ────────────────────────────────────────────────────────────
 
     /// Thin wrapper around an async-nats JetStream context.

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -690,6 +690,179 @@ fn extract_rel_path_from_state(state_key: &str, local_root: &Path) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use opendal::services::Memory;
+
+    fn memory_op() -> Operator {
+        Operator::new(Memory::default()).unwrap().finish()
+    }
+
+    // ── list_remote_index ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_remote_index_empty() {
+        let op = memory_op();
+        let index = list_remote_index(&op, "data").await.unwrap();
+        assert!(index.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_remote_index_finds_entries() {
+        let op = memory_op();
+        op.write(
+            "data/index/file1.txt",
+            b"manifest_hash=aaa\nsize=100\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+        op.write(
+            "data/index/file2.txt",
+            b"manifest_hash=bbb\nsize=200\nchunks=2\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let index = list_remote_index(&op, "data").await.unwrap();
+        assert_eq!(index.len(), 2);
+        assert_eq!(index["file1.txt"].manifest_hash, "aaa");
+        assert_eq!(index["file2.txt"].manifest_hash, "bbb");
+        assert_eq!(index["file2.txt"].size, 200);
+    }
+
+    // ── reconcile plan: local-only → push ────────────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_local_only_file_generates_push() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+        std::fs::write(local_root.join("new_file.txt"), b"hello").unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let state = crate::state::StateCache::open(&state_path).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.pushes, 1,
+            "local-only file should generate a push"
+        );
+        assert!(
+            plan.actions.iter().any(|a| matches!(a, ReconcileAction::Push { rel_path, .. } if rel_path == "new_file.txt")),
+            "push action should target new_file.txt"
+        );
+    }
+
+    // ── reconcile plan: remote-only → pull ───────────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_remote_only_file_generates_pull() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+
+        // Write a remote index entry (no local file)
+        op.write(
+            "data/index/remote_only.txt",
+            b"manifest_hash=abc123\nsize=50\nchunks=1\n".to_vec(),
+        )
+        .await
+        .unwrap();
+
+        let state_path = dir.path().join("state.json");
+        let state = crate::state::StateCache::open(&state_path).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.pulls, 1,
+            "remote-only file should generate a pull"
+        );
+        assert!(
+            plan.actions.iter().any(|a| matches!(a, ReconcileAction::Pull { rel_path, .. } if rel_path == "remote_only.txt")),
+            "pull action should target remote_only.txt"
+        );
+    }
+
+    // ── reconcile plan: both exist, up-to-date ───────────────────────────
+
+    #[tokio::test]
+    async fn reconcile_matching_files_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path();
+
+        let content = b"matching content";
+        let hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(content));
+
+        // Write local file
+        std::fs::write(local_root.join("same.txt"), content).unwrap();
+
+        // Write matching remote index + manifest
+        let index_entry = format!("manifest_hash={hash}\nsize={}\nchunks=1\n", content.len());
+        op.write("data/index/same.txt", index_entry.into_bytes())
+            .await
+            .unwrap();
+
+        let manifest_json = serde_json::json!({
+            "version": 2,
+            "file_hash": hash,
+            "file_size": content.len(),
+            "chunks": [],
+            "vclock": {"clocks": {"neo": 1}},
+            "written_by": "neo",
+            "written_at": 0
+        });
+        op.write(
+            &format!("data/manifests/{hash}"),
+            serde_json::to_vec(&manifest_json).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Set up state cache with matching entry
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        let local_file = local_root.join("same.txt");
+        let mut vc = crate::conflict::VectorClock::new();
+        vc.tick("neo");
+        let sync_state = crate::state::make_sync_state_full(
+            &local_file,
+            hash.clone(),
+            1,
+            format!("data/manifests/{hash}"),
+            vc,
+            "neo".into(),
+        )
+        .unwrap();
+        state.set(&local_file, sync_state);
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan.summary.up_to_date, 1,
+            "matching files should be up-to-date"
+        );
+        assert_eq!(plan.summary.pushes, 0);
+        assert_eq!(plan.summary.pulls, 0);
+        assert_eq!(plan.summary.conflicts, 0);
+    }
+
+    // ── original tests ───────────────────────────────────────────────────
 
     #[test]
     fn test_parse_index_entry() {


### PR DESCRIPTION
Superseded by Jesssullivan/tummycrypt PR (rebased onto correct upstream)