### PR TITLE
sync: merge origin/main into tinyland main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ Current release-proof posture is tracked in `docs/release/evidence/` and
 `docs/ops/product-reality-and-priority.md`; older entries below may describe
 historical release intent rather than the current supported/proven surface.
 
+## [0.12.14] - 2026-06-03
+
+First finalized release of the 0.12.13→0.12.14 line (0.12.13 shipped only as
+rc1–rc4 prereleases). Captures the fail-closed secrets deny-set and the
+daemon-startup reliability fixes that landed on `main` after `v0.12.13-rc4` —
+previously present in deployed builds but in no published tag.
+
+### Security
+
+- **Fail-closed secrets deny-set in the sync `Blacklist`** (TIN-1737,
+  `crates/tcfs-sync/src/blacklist.rs`): secret-bearing paths are never synced —
+  `.ssh/`, `.gnupg/`, `sops-nix/` directories; `auth.json`, `.netrc`,
+  `.pgpass`, `.credentials.json` files; `.env*` files; and `.sqlite*`/`.db*`
+  suffixes. Enforced fail-closed so a misconfiguration cannot leak credentials.
+- **Per-device file-key wrapping substrate** (TIN-1417, behind a flag,
+  default off): age-recipient per-device key wrapping is now available via
+  `crypto.per_device_wrapping`; the default remains shared-master so existing
+  fleets are unaffected until the migration lands.
+- **Enrollment & auth hardening**: single-use enrollment invites; admin-gated
+  enrollment control RPCs; device-invite enrollment bootstrap (TIN-1424);
+  real local age identities generated on enrollment; auth sessions are now
+  persisted and attached to protected RPCs.
+
+### Added
+
+- **Device registry sync during enrollment** (#476): enrolling a device now
+  publishes it into the shared device registry.
+- **FileProvider config rendering** (#466, TIN-1425): the daemon and CLI
+  render the FileProvider config from the active config; `tcfs init` writes a
+  config; FileProvider surface contract is asserted in CI (TIN-1547).
+- **`natsTls` config option** (default `false`, #473).
+- **Storage restore SLO budgets** in CI (TIN-1622).
+
+### Fixed
+
+- **Daemon control-plane startup hangs** (TIN-1758): readiness no longer blocks
+  on remote index discovery; the FileProvider socket bind is kept off the
+  runtime workers and serves late socket binds — the daemon comes up reliably
+  under load.
+- **`tcfs pull <abspath>`** writing into a hash-named file in the cwd instead of
+  the requested path (#473).
+- Hardened large-restore retry observability; avoided a macOS LaunchAgent
+  config restart loop (#457).
+
 ## [0.12.13] - 2026-05-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-auth"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-chunks"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cli"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-cloudfilter"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-core"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "prost",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-crypto"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "aes-siv",
  "age",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-dbus"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-e2e"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-file-provider"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-fuse"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-mcp"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "hyper-util",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-nfs"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-secrets"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "aes-gcm",
  "age",
@@ -5415,7 +5415,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sops"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-storage"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "opendal",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-sync"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "age",
  "anyhow",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-tui"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -5503,7 +5503,7 @@ dependencies = [
 
 [[package]]
 name = "tcfs-vfs"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "tcfsd"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.12.13"
+version = "0.12.14"
 edition = "2021"
 authors = ["TummyCrypt Contributors"]
 license = "MIT OR Apache-2.0"

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1441,6 +1441,7 @@ async fn cmd_pull_with_operator(
 
     state.flush().context("flushing state cache")?;
     remove_adjacent_stub_after_pull(&result.local_path).await?;
+    restore_git_history_after_pull(&result.local_path).await?;
 
     pb.finish_with_message("done".to_string());
     println!();
@@ -1489,6 +1490,43 @@ async fn remove_adjacent_stub_after_pull(local_path: &Path) -> Result<()> {
             Err(err).with_context(|| format!("removing stale stub: {}", stub_path.display()))
         }
     }
+}
+
+/// If the pulled file is a TCFS git bundle (`.git-tcfs-bundle`), reconstruct
+/// the repo's `.git` metadata in place so the rehydrated working tree has
+/// working history (`git log` / `git status` / `git fetch`).
+///
+/// The bundle artifact is intentionally left in place: it is a synced object,
+/// so deleting it locally would propagate as a deletion to peers on the next
+/// reconcile. Artifact cleanup (gitignore / post-restore prune) is tracked as
+/// a follow-up.
+async fn restore_git_history_after_pull(local_path: &Path) -> Result<()> {
+    let is_bundle = local_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == tcfs_sync::git_safety::GIT_BUNDLE_REL_PATH)
+        .unwrap_or(false);
+    if !is_bundle {
+        return Ok(());
+    }
+    let Some(repo_root) = local_path.parent().map(|p| p.to_path_buf()) else {
+        return Ok(());
+    };
+    let bundle = local_path.to_path_buf();
+    // git invokes blocking subprocesses; keep them off the async runtime.
+    tokio::task::spawn_blocking(move || {
+        tcfs_sync::git_safety::restore_git_bundle_into(&bundle, &repo_root)
+    })
+    .await
+    .context("joining git bundle restore task")?
+    .with_context(|| {
+        format!(
+            "restoring git history from bundle: {}",
+            local_path.display()
+        )
+    })?;
+    println!("  restored git history from bundle");
+    Ok(())
 }
 
 async fn cmd_pull(

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2833,6 +2833,14 @@ pub fn collect_files(root: &Path, config: &CollectConfig) -> Result<CollectResul
         &blacklist,
         &mut visited,
     )?;
+
+    // Bundle mode: for every enrolled git repo, capture `.git` as a single
+    // `git bundle` and add the bundle to the upload set as a normal object.
+    // The raw `.git/*` internals were skipped by `collect_files_inner`.
+    if config.sync_git_dirs && config.git_sync_mode == "bundle" {
+        collect_git_bundles(root, &mut files);
+    }
+
     files.sort(); // deterministic order
     symlinks.sort();
     empty_dirs.sort();
@@ -3010,6 +3018,123 @@ fn collect_files_inner(
     }
 
     Ok(())
+}
+
+/// Walk `root` for git working trees (directories containing a `.git`
+/// directory) and, for each one that is safe to snapshot, create a git bundle
+/// and append its path to `files` so it is uploaded as a normal TCFS object.
+///
+/// Repos with in-progress operations (rebase, merge, lockfiles) are skipped
+/// this cycle and will be retried on the next sync once the operation settles.
+/// Bundle staleness is handled implicitly: `git bundle create --all` always
+/// reflects current refs, and the resulting object only re-uploads chunks that
+/// actually changed (content-addressed dedup).
+fn collect_git_bundles(root: &Path, files: &mut Vec<PathBuf>) {
+    let mut repos = Vec::new();
+    find_git_repos(root, &mut repos);
+    for repo_root in repos {
+        let git_dir = repo_root.join(".git");
+        let safety = crate::git_safety::git_is_safe(&git_dir);
+        if !safety.blocking.is_empty() {
+            warn!(
+                repo = %repo_root.display(),
+                blocking = ?safety.blocking,
+                "skipping git bundle: active git operation in progress"
+            );
+            continue;
+        }
+        match crate::git_safety::snapshot_git_for_sync(&repo_root) {
+            Ok(bundle_path) => {
+                debug!(repo = %repo_root.display(), bundle = %bundle_path.display(), "captured git bundle");
+                files.push(bundle_path);
+            }
+            Err(e) => {
+                warn!(repo = %repo_root.display(), "git bundle failed: {e}");
+            }
+        }
+    }
+}
+
+/// Recursively find directories under `root` that contain a `.git` directory
+/// (i.e. git working-tree roots). Does not descend into `.git` itself.
+fn find_git_repos(dir: &Path, out: &mut Vec<PathBuf>) {
+    if dir.join(".git").is_dir() {
+        out.push(dir.to_path_buf());
+        // Still descend to catch nested submodule/worktree repos.
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if !ft.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == ".git" {
+            continue;
+        }
+        find_git_repos(&path, out);
+    }
+}
+
+/// Restore git history from any TCFS bundles materialized under `root`.
+///
+/// Call this after a pull/rehydrate completes: for every
+/// `.git-tcfs-bundle` file found under `root`, restore the repo's `.git`
+/// metadata in place so `git log` / `git status` / `git fetch` work on the
+/// peer. The synced working-tree files are left untouched.
+///
+/// Returns the number of repos successfully restored.
+pub fn restore_git_bundles_under(root: &Path) -> usize {
+    let mut bundles = Vec::new();
+    find_git_bundles(root, &mut bundles);
+    let mut restored = 0usize;
+    for bundle in bundles {
+        let Some(repo_root) = bundle.parent() else {
+            continue;
+        };
+        match crate::git_safety::restore_git_bundle_into(&bundle, repo_root) {
+            Ok(()) => {
+                info!(repo = %repo_root.display(), "restored git history from bundle");
+                restored += 1;
+            }
+            Err(e) => {
+                warn!(repo = %repo_root.display(), "git bundle restore failed: {e}");
+            }
+        }
+    }
+    restored
+}
+
+/// Recursively find `.git-tcfs-bundle` files under `dir`.
+fn find_git_bundles(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else { continue };
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if name == crate::git_safety::GIT_BUNDLE_REL_PATH {
+                out.push(path.clone());
+            }
+        }
+        if ft.is_dir() {
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if name == ".git" {
+                continue;
+            }
+            find_git_bundles(&path, out);
+        }
+    }
 }
 
 /// Normalize a filesystem path into a stable S3 index key component.

--- a/crates/tcfs-sync/src/git_safety.rs
+++ b/crates/tcfs-sync/src/git_safety.rs
@@ -5,6 +5,13 @@
 
 use std::path::Path;
 
+/// Relative path (under the repo working root) where the TCFS git bundle is
+/// written and synced as a normal object. Keeping it inside the working tree
+/// (not under `.git/`) means it flows through the regular file collector and
+/// is visible to the peer pull as an ordinary path, while the raw `.git/*`
+/// internals are skipped by the collector in bundle mode.
+pub const GIT_BUNDLE_REL_PATH: &str = ".git-tcfs-bundle";
+
 /// Result of checking whether a .git directory is safe to sync.
 #[derive(Debug, Clone, Default)]
 pub struct GitSafetyCheck {
@@ -76,7 +83,7 @@ pub fn git_is_safe(git_dir: &Path) -> GitSafetyCheck {
 /// Runs `git bundle create --all` to create a single file containing
 /// all refs and objects, suitable for transporting a complete repository.
 pub fn snapshot_git_for_sync(repo_root: &Path) -> anyhow::Result<std::path::PathBuf> {
-    let bundle_path = repo_root.join(".git-tcfs-bundle");
+    let bundle_path = repo_root.join(GIT_BUNDLE_REL_PATH);
 
     let output = std::process::Command::new("git")
         .args(["bundle", "create", &bundle_path.to_string_lossy(), "--all"])
@@ -92,7 +99,67 @@ pub fn snapshot_git_for_sync(repo_root: &Path) -> anyhow::Result<std::path::Path
     Ok(bundle_path)
 }
 
-/// Restore a git repository from a bundle.
+/// Restore git history from a TCFS bundle into an existing working tree.
+///
+/// Unlike a fresh `git clone`, this is designed for the rehydrate path where
+/// the working-tree files have already been materialized by TCFS as normal
+/// objects: only the `.git` metadata (objects, refs, logs) is missing. It:
+///
+/// 1. `git init`s the repo in place if there is no `.git` directory yet.
+/// 2. `git fetch`es every ref from the bundle into the live object store
+///    (`+refs/*:refs/*`), which repopulates branches, tags, and history.
+/// 3. Restores `HEAD` to the bundle's default branch so `git log` / `git
+///    status` / `git fetch` work against a real ref.
+///
+/// The working-tree files are left untouched: after this runs, `git status`
+/// compares the freshly-restored index/HEAD against the already-synced files,
+/// so a faithfully-synced tree reports clean.
+pub fn restore_git_bundle_into(bundle: &Path, repo_root: &Path) -> anyhow::Result<()> {
+    if !bundle.exists() {
+        anyhow::bail!("git bundle not found: {}", bundle.display());
+    }
+
+    let git_dir = repo_root.join(".git");
+    if !git_dir.exists() {
+        run_git(repo_root, &["init", "--quiet"]).map_err(|e| anyhow::anyhow!("git init: {e}"))?;
+    }
+
+    // Park HEAD on a throwaway unborn branch before fetching. A fresh `git
+    // init` puts HEAD on `refs/heads/main` (or `master`); git then refuses
+    // `+refs/*:refs/*` because it would fetch into the currently checked-out
+    // branch. Pointing HEAD at a ref the bundle does not contain makes every
+    // real branch non-current, so the mirror fetch succeeds. We restore HEAD
+    // to the real branch immediately after.
+    run_git(
+        repo_root,
+        &["symbolic-ref", "HEAD", "refs/heads/__tcfs_bundle_restore"],
+    )
+    .map_err(|e| anyhow::anyhow!("parking HEAD before bundle fetch: {e}"))?;
+
+    // Pull every ref from the bundle into the live repo. `+refs/*:refs/*`
+    // mirrors heads, tags, and remotes so history is complete.
+    let bundle_str = bundle.to_string_lossy().to_string();
+    run_git(
+        repo_root,
+        &["fetch", "--quiet", &bundle_str, "+refs/*:refs/*"],
+    )
+    .map_err(|e| anyhow::anyhow!("git fetch from bundle: {e}"))?;
+
+    // Restore HEAD to the bundle's default branch. The bundle stores the
+    // symbolic HEAD target; resolve it so the peer lands on the same branch.
+    if let Some(branch) = bundle_head_branch(bundle) {
+        // Point HEAD at the branch without touching the working tree.
+        let _ = run_git(repo_root, &["symbolic-ref", "HEAD", &branch]);
+        // Make the index match HEAD without overwriting synced files.
+        let _ = run_git(repo_root, &["reset", "--mixed", "--quiet"]);
+    }
+
+    Ok(())
+}
+
+/// Backwards-compatible clone-based restore (creates a fresh checkout at
+/// `target`). Retained for callers that want a standalone clone rather than an
+/// in-place working-tree restore.
 pub fn restore_git_from_bundle(bundle: &Path, target: &Path) -> anyhow::Result<()> {
     let output = std::process::Command::new("git")
         .args([
@@ -109,6 +176,56 @@ pub fn restore_git_from_bundle(bundle: &Path, target: &Path) -> anyhow::Result<(
     }
 
     Ok(())
+}
+
+/// Run a git command in `cwd`, returning an error with captured stderr on
+/// non-zero exit.
+fn run_git(cwd: &Path, args: &[&str]) -> anyhow::Result<()> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| anyhow::anyhow!("running git {args:?}: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git {args:?} failed: {stderr}");
+    }
+    Ok(())
+}
+
+/// Resolve the bundle's default HEAD branch ref (e.g. `refs/heads/main`) by
+/// listing its refs. Returns `None` if HEAD cannot be determined.
+fn bundle_head_branch(bundle: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["bundle", "list-heads", &bundle.to_string_lossy()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let listing = String::from_utf8_lossy(&output.stdout);
+    // `git bundle list-heads` prints `<sha> HEAD` for the symbolic head and
+    // `<sha> refs/heads/<branch>` lines. Find the SHA that HEAD points at,
+    // then map it back to a concrete branch ref.
+    let mut head_sha: Option<String> = None;
+    for line in listing.lines() {
+        let mut parts = line.split_whitespace();
+        let sha = parts.next().unwrap_or_default();
+        let refname = parts.next().unwrap_or_default();
+        if refname == "HEAD" {
+            head_sha = Some(sha.to_string());
+        }
+    }
+    let head_sha = head_sha?;
+    for line in listing.lines() {
+        let mut parts = line.split_whitespace();
+        let sha = parts.next().unwrap_or_default();
+        let refname = parts.next().unwrap_or_default();
+        if sha == head_sha && refname.starts_with("refs/heads/") {
+            return Some(refname.to_string());
+        }
+    }
+    None
 }
 
 /// Acquire a cooperative lock on .git/tcfs.lock for raw sync mode.

--- a/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
+++ b/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
@@ -78,8 +78,7 @@ async fn git_bundle_mode_preserves_history_on_peer() {
     let op = memory_operator();
     let prefix = "test/git-bundle";
 
-    let mut state =
-        tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
+    let mut state = tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
 
     // Bundle mode: include .git, but capture it as a bundle (not raw walk).
     let config = tcfs_sync::engine::CollectConfig {
@@ -118,7 +117,10 @@ async fn git_bundle_mode_preserves_history_on_peer() {
     )
     .await
     .expect("push tree in bundle mode");
-    assert!(uploaded >= 3, "expected README, file2, bundle: got {uploaded}");
+    assert!(
+        uploaded >= 3,
+        "expected README, file2, bundle: got {uploaded}"
+    );
 
     // ── Peer rehydrate ───────────────────────────────────────────────────
     let peer_tmp = TempDir::new().unwrap();
@@ -130,10 +132,9 @@ async fn git_bundle_mode_preserves_history_on_peer() {
 
     // Pull every synced working-tree path (incl. the bundle) into the peer.
     for rel in &rels {
-        let manifest =
-            tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
-                .await
-                .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
+        let manifest = tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
+            .await
+            .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
         let dst = peer_repo.join(rel);
         std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
         tcfs_sync::engine::download_file_with_device(

--- a/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
+++ b/crates/tcfs-sync/tests/git_bundle_roundtrip.rs
@@ -1,0 +1,195 @@
+//! Integration test: git-bundle sync → peer rehydrate preserves history.
+//!
+//! Verifies the bundle-mode path end-to-end:
+//!   1. Create a temp git repo with >=2 commits.
+//!   2. Push the tree in bundle mode (sync_git_dirs=true, git_sync_mode=bundle).
+//!      The raw `.git/*` internals are NOT walked; instead a single
+//!      `.git-tcfs-bundle` object is synced.
+//!   3. Pull every synced object into a fresh peer directory.
+//!   4. Restore git history from the bundle on the peer.
+//!   5. Assert `git log` shows both commits and `git status` is clean.
+
+use opendal::Operator;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn memory_operator() -> Operator {
+    Operator::new(opendal::services::Memory::default())
+        .expect("memory operator")
+        .finish()
+}
+
+fn git(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("running git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_stdout(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("running git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn init_repo_with_two_commits(dir: &Path) {
+    git(dir, &["init", "--quiet", "-b", "main"]);
+    git(dir, &["config", "user.email", "test@tcfs.local"]);
+    git(dir, &["config", "user.name", "TCFS Test"]);
+    git(dir, &["config", "commit.gpgsign", "false"]);
+
+    std::fs::write(dir.join("README.md"), b"first\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "--quiet", "-m", "first commit"]);
+
+    std::fs::write(dir.join("file2.txt"), b"second\n").unwrap();
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "--quiet", "-m", "second commit"]);
+}
+
+#[tokio::test]
+async fn git_bundle_mode_preserves_history_on_peer() {
+    // Skip gracefully if git is unavailable in the environment.
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available; skipping git_bundle_mode_preserves_history_on_peer");
+        return;
+    }
+
+    let src_tmp = TempDir::new().unwrap();
+    let repo = src_tmp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    init_repo_with_two_commits(&repo);
+
+    let op = memory_operator();
+    let prefix = "test/git-bundle";
+
+    let mut state =
+        tcfs_sync::state::StateCache::open(&src_tmp.path().join("state.db")).unwrap();
+
+    // Bundle mode: include .git, but capture it as a bundle (not raw walk).
+    let config = tcfs_sync::engine::CollectConfig {
+        sync_git_dirs: true,
+        git_sync_mode: "bundle".into(),
+        sync_empty_dirs: false,
+        ..Default::default()
+    };
+
+    // Sanity: the collector must NOT walk raw `.git/*` internals, but MUST
+    // include the synthesized bundle object.
+    let collected = tcfs_sync::engine::collect_files(&repo, &config).unwrap();
+    let rels: Vec<String> = collected
+        .files
+        .iter()
+        .map(|p| p.strip_prefix(&repo).unwrap().to_string_lossy().to_string())
+        .collect();
+    assert!(
+        rels.iter().any(|r| r == ".git-tcfs-bundle"),
+        "bundle object should be in collected set: {rels:?}"
+    );
+    assert!(
+        !rels.iter().any(|r| r.starts_with(".git/")),
+        "raw .git internals must not be walked in bundle mode: {rels:?}"
+    );
+
+    let (uploaded, _skipped, _bytes) = tcfs_sync::engine::push_tree_with_device(
+        &op,
+        &repo,
+        prefix,
+        &mut state,
+        None,
+        "neo",
+        Some(&config),
+        None,
+    )
+    .await
+    .expect("push tree in bundle mode");
+    assert!(uploaded >= 3, "expected README, file2, bundle: got {uploaded}");
+
+    // ── Peer rehydrate ───────────────────────────────────────────────────
+    let peer_tmp = TempDir::new().unwrap();
+    let peer_repo = peer_tmp.path().join("repo");
+    std::fs::create_dir_all(&peer_repo).unwrap();
+
+    let mut restore_state =
+        tcfs_sync::state::StateCache::open(&peer_tmp.path().join("restore-state.db")).unwrap();
+
+    // Pull every synced working-tree path (incl. the bundle) into the peer.
+    for rel in &rels {
+        let manifest =
+            tcfs_sync::engine::resolve_manifest_path(&op, rel, prefix, Some(&repo))
+                .await
+                .unwrap_or_else(|e| panic!("resolve manifest for {rel}: {e}"));
+        let dst = peer_repo.join(rel);
+        std::fs::create_dir_all(dst.parent().unwrap()).unwrap();
+        tcfs_sync::engine::download_file_with_device(
+            &op,
+            &manifest,
+            &dst,
+            prefix,
+            None,
+            "honey",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("download {rel}: {e}"));
+    }
+
+    // Before restore the peer has working-tree files but no `.git` history.
+    assert!(peer_repo.join("README.md").exists());
+    assert!(peer_repo.join("file2.txt").exists());
+    assert!(peer_repo.join(".git-tcfs-bundle").exists());
+    assert!(!peer_repo.join(".git").exists());
+
+    // Restore git history from the bundle.
+    let restored = tcfs_sync::engine::restore_git_bundles_under(peer_tmp.path());
+    assert_eq!(restored, 1, "exactly one repo should be restored");
+
+    // ── Assertions: history + clean status on the peer ─────────────────────
+    let log = git_stdout(&peer_repo, &["log", "--oneline"]);
+    assert!(
+        log.contains("first commit"),
+        "peer git log should include first commit: {log}"
+    );
+    assert!(
+        log.contains("second commit"),
+        "peer git log should include second commit: {log}"
+    );
+    let count = log.lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(count, 2, "peer should have exactly 2 commits: {log}");
+
+    // `git status` should be clean. The TCFS bundle artifact is the only
+    // untracked file; ignore it so the working tree is otherwise pristine.
+    let status = git_stdout(
+        &peer_repo,
+        &["status", "--porcelain", "--untracked-files=all"],
+    );
+    let dirty: Vec<&str> = status
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| !l.ends_with(".git-tcfs-bundle"))
+        .collect();
+    assert!(
+        dirty.is_empty(),
+        "peer working tree should be clean (excluding bundle artifact): {dirty:?}"
+    );
+
+    // HEAD should resolve to the same branch the source was on.
+    let branch = git_stdout(&peer_repo, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert_eq!(branch.trim(), "main", "peer HEAD should be on main");
+}

--- a/scripts/macos-fileprovider-preflight.sh
+++ b/scripts/macos-fileprovider-preflight.sh
@@ -206,9 +206,34 @@ detect_app_path() {
   exit 1
 }
 
+canonical_path() {
+  local path="$1"
+  local parent
+  local base
+
+  if [[ -d "$path" ]]; then
+    (cd "$path" && pwd -P)
+    return
+  fi
+
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  if [[ -d "$parent" ]]; then
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+    return
+  fi
+
+  printf '%s\n' "$path"
+}
+
 check_pluginkit() {
   local output
   local count
+  local expected_extension
+  local expected_extension_canonical
+  local matched_expected_path=0
+  local registered_path_count=0
+  local path
 
   output="$(pluginkit -m -A -D -vvv -i "$PLUGIN_ID" 2>&1)" || {
     echo "pluginkit lookup failed for $PLUGIN_ID" >&2
@@ -233,6 +258,36 @@ check_pluginkit() {
       print_pluginkit_duplicate_hint "$output"
       exit 1
     fi
+  fi
+
+  expected_extension="$APP_PATH/Contents/Extensions/TCFSFileProvider.appex"
+  expected_extension_canonical="$(canonical_path "$expected_extension")"
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    registered_path_count=$((registered_path_count + 1))
+    if [[ "$(canonical_path "$path")" == "$expected_extension_canonical" ]]; then
+      matched_expected_path=1
+    fi
+  done < <(
+    awk '
+      /^[[:space:]]*Path = / {
+        path = $0
+        sub(/^[[:space:]]*Path = /, "", path)
+        print path
+      }
+    ' <<<"$output"
+  )
+
+  if (( registered_path_count == 0 )); then
+    echo "pluginkit output did not include a FileProvider extension path for $PLUGIN_ID" >&2
+    exit 1
+  fi
+
+  if (( matched_expected_path == 0 )); then
+    echo "pluginkit registered FileProvider extension does not match selected app path" >&2
+    echo "selected extension: $expected_extension_canonical" >&2
+    print_pluginkit_duplicate_hint "$output"
+    exit 1
   fi
 }
 

--- a/scripts/macos-postinstall-smoke.sh
+++ b/scripts/macos-postinstall-smoke.sh
@@ -488,6 +488,17 @@ run_bounded_append_to_log() {
   return "$status"
 }
 
+swift_helper_available() {
+  command -v swift >/dev/null 2>&1
+}
+
+run_swift_helper() {
+  # Nix dev shells export SDKROOT/DEVELOPER_DIR to the Nix Apple SDK. The
+  # system Swift driver then sees a mismatched SDK and fails before the helper
+  # can exercise FileProvider. Use the host Xcode defaults for these probes.
+  /usr/bin/env -u SDKROOT -u DEVELOPER_DIR swift "$@"
+}
+
 wait_for_pid_with_timeout() {
   local pid="$1"
   local timeout_secs="$2"
@@ -1680,12 +1691,12 @@ run_coordinated_root_listing() {
 
   [[ "$COORDINATED_READ" != "0" ]] || return 2
   [[ -f "$helper" ]] || return 2
-  command -v swift >/dev/null 2>&1 || return 2
+  swift_helper_available || return 2
 
   run_bounded_to_log \
     "$label" \
     "$LOG_SHOW_TIMEOUT_SECS" \
-    swift "$helper" "$root" || return "$?"
+    run_swift_helper "$helper" "$root" || return "$?"
 
   listing="$(cat "$LOG_DIR/${label}.log" 2>/dev/null || true)"
   [[ -n "$listing" ]] || return 1
@@ -1810,8 +1821,8 @@ read_fileprovider_file() {
   local helper="$REPO_ROOT/scripts/macos-fileprovider-coordinated-read.swift"
   local pid
 
-  if [[ "$COORDINATED_READ" != "0" && -f "$helper" ]] && command -v swift >/dev/null 2>&1; then
-    swift "$helper" "$path" "$hydrated_copy" &
+  if [[ "$COORDINATED_READ" != "0" && -f "$helper" ]] && swift_helper_available; then
+    run_swift_helper "$helper" "$path" "$hydrated_copy" &
     pid="$!"
     wait_for_pid_with_timeout "$pid" "$READ_TIMEOUT_SECS" "coordinated FileProvider read"
   else

--- a/scripts/test-macos-fileprovider-preflight.sh
+++ b/scripts/test-macos-fileprovider-preflight.sh
@@ -134,8 +134,9 @@ fi
 EOF
 cat >"$FAKE_BIN/pluginkit" <<'EOF'
 #!/usr/bin/env bash
+app_path="${TCFS_FAKE_PLUGIN_APP_PATH:-/Users/test/Applications/TCFSProvider.app}"
 printf 'io.tinyland.tcfs.fileprovider(0.2.0)\n'
-printf '            Path = /Users/test/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex\n'
+printf '            Path = %s/Contents/Extensions/TCFSFileProvider.appex\n' "$app_path"
 if [[ "${TCFS_FAKE_PLUGIN_DUPES:-0}" == "1" ]]; then
   printf 'io.tinyland.tcfs.fileprovider(0.1.0)\n'
   printf '            Path = /Users/test/git/tummycrypt/build/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex\n'
@@ -223,6 +224,7 @@ fi
 exit 1
 EOF
 chmod +x "$FAKE_BIN"/*
+export TCFS_FAKE_PLUGIN_APP_PATH="$APP_PATH"
 
 OUT="${TMPDIR}/positive.out"
 ERR="${TMPDIR}/positive.err"
@@ -379,6 +381,27 @@ assert_contains "${TMPDIR}/dupes.combined" "multiple FileProvider registrations 
 assert_contains "${TMPDIR}/dupes.combined" "registered FileProvider extension paths:"
 assert_contains "${TMPDIR}/dupes.combined" "/Users/test/git/tummycrypt/build/TCFSProvider.app"
 assert_contains "${TMPDIR}/dupes.combined" "cleanup is not performed automatically"
+
+STALE_OUT="${TMPDIR}/stale-plugin.out"
+STALE_ERR="${TMPDIR}/stale-plugin.err"
+if env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_PLUGIN_APP_PATH=/Users/test/Applications/TCFSProvider.app \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --fileprovider-config "$FILEPROVIDER_CONFIG" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    >"$STALE_OUT" \
+    2>"$STALE_ERR"; then
+  printf 'expected stale pluginkit registration to fail\n' >&2
+  exit 1
+fi
+cat "$STALE_OUT" "$STALE_ERR" >"${TMPDIR}/stale-plugin.combined"
+assert_contains "${TMPDIR}/stale-plugin.combined" "pluginkit registered FileProvider extension does not match selected app path"
+assert_contains "${TMPDIR}/stale-plugin.combined" "selected extension:"
+assert_contains "${TMPDIR}/stale-plugin.combined" "TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex"
+assert_contains "${TMPDIR}/stale-plugin.combined" "/Users/test/Applications/TCFSProvider.app/Contents/Extensions/TCFSFileProvider.appex"
+assert_contains "${TMPDIR}/stale-plugin.combined" "cleanup is not performed automatically"
 
 UNAVAILABLE_OUT="${TMPDIR}/unavailable.out"
 UNAVAILABLE_ERR="${TMPDIR}/unavailable.err"

--- a/scripts/test-macos-postinstall-smoke.sh
+++ b/scripts/test-macos-postinstall-smoke.sh
@@ -400,6 +400,17 @@ if [[ -n "${TCFS_FAKE_FIND_HANG_TARGET:-}" ]]; then
 fi
 exec /usr/bin/find "$@"
 EOF
+cat >"$FAKE_BIN/env" <<'EOF'
+#!/usr/bin/env bash
+exec /usr/bin/env "$@"
+EOF
+cat >"$FAKE_BIN/xattr" <<'EOF'
+#!/usr/bin/env bash
+for path in "$@"; do
+  [[ "$path" == -* ]] && continue
+  printf '%s: %s\n' "com.apple.provenance" "$path"
+done
+EOF
 cat >"$APP_PATH/Contents/MacOS/TCFSProvider" <<'EOF'
 #!/usr/bin/env bash
 if [[ -n "${TCFS_FAKE_HOST_BINARY_LOG:-}" ]]; then
@@ -485,6 +496,10 @@ if [[ -n "${TCFS_FAKE_SWIFT_LOG:-}" ]]; then
   printf 'swift' >>"$TCFS_FAKE_SWIFT_LOG"
   printf ' %q' "$@" >>"$TCFS_FAKE_SWIFT_LOG"
   printf '\n' >>"$TCFS_FAKE_SWIFT_LOG"
+fi
+if [[ -n "${TCFS_FAKE_SWIFT_ENV_LOG:-}" ]]; then
+  printf 'SDKROOT=%s\n' "${SDKROOT:-}" >>"$TCFS_FAKE_SWIFT_ENV_LOG"
+  printf 'DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}" >>"$TCFS_FAKE_SWIFT_ENV_LOG"
 fi
 
 helper="${1:-}"
@@ -885,6 +900,8 @@ assert_fails_contains \
 assert_fails_contains \
   "FileProvider extension used build-time embedded config" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_EXTENSION_LOG="2026-04-30 TCFSFileProvider extension loadConfig: loaded from build-time embedded config" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -900,6 +917,8 @@ assert_fails_contains \
 assert_fails_contains \
   "FileProvider extension did not log shared Keychain config load" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_EXTENSION_LOG="" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -915,6 +934,8 @@ assert_fails_contains \
 assert_fails_contains \
   "expected file is not backed by a visible remote index entry" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_INDEX_STATUS="missing_index" \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -931,6 +952,8 @@ printf 'wrong content\n' >"${TMPDIR}/wrong-content.txt"
 assert_fails_contains \
   "hydrated file content mismatch" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
       --config "$CONFIG_PATH" \
@@ -1144,6 +1167,8 @@ mkdir -p "$DISABLED_ROOT"
 assert_fails_contains \
   "FileProvider domain is disabled by macOS (NSFileProviderErrorDomain -2011)" \
   env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+    TCFS_COORDINATED_READ=0 \
+    LOG_SHOW_TIMEOUT_SECS=1 \
     TCFS_FAKE_FILEPROVIDER_SYSTEM_LOG='2026-05-01 fileproviderd FP -2011 "Sync is not enabled for TCFSProvider."' \
     bash "$SCRIPT" \
       --expected-version 0.12.2 \
@@ -1151,10 +1176,38 @@ assert_fails_contains \
       --app-path "$APP_PATH" \
       --cloud-root "$DISABLED_ROOT" \
       --log-dir "${TMPDIR}/domain-disabled-logs" \
-      --timeout 2
+      --timeout 1
 
 assert_contains \
   "${TMPDIR}/domain-disabled-logs/fileprovider-system.log" \
   'Sync is not enabled for TCFSProvider'
+
+SWIFT_ENV_LOG="${TMPDIR}/swift-env.log"
+SWIFT_ENV_OUT="${TMPDIR}/swift-env.out"
+if ! env PATH="$FAKE_BIN:$PATH" HOME="$HOME_DIR" \
+  SDKROOT="/nix/store/bad-apple-sdk" \
+  DEVELOPER_DIR="/nix/store/bad-developer-dir" \
+  TCFS_FAKE_OPEN_LOG="$OPEN_LOG" \
+  TCFS_FAKE_FIND_PERMISSION_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_SWIFT_LIST_TARGET="$CLOUD_ROOT" \
+  TCFS_FAKE_SWIFT_LIST_OUTPUT="$CLOUD_ROOT/Projects" \
+  TCFS_FAKE_SWIFT_ENV_LOG="$SWIFT_ENV_LOG" \
+  LOG_SHOW_TIMEOUT_SECS=1 \
+  bash "$SCRIPT" \
+    --expected-version 0.12.2 \
+    --config "$CONFIG_PATH" \
+    --app-path "$APP_PATH" \
+    --cloud-root "$CLOUD_ROOT" \
+    --log-dir "${TMPDIR}/swift-env-logs" \
+    --timeout 2 \
+    >"$SWIFT_ENV_OUT" 2>&1; then
+  cat "$SWIFT_ENV_OUT" >&2 || true
+  exit 1
+fi
+assert_contains "$SWIFT_ENV_OUT" "coordinated enumeration sample:"
+assert_contains "$SWIFT_ENV_LOG" "SDKROOT="
+assert_contains "$SWIFT_ENV_LOG" "DEVELOPER_DIR="
+assert_not_contains "$SWIFT_ENV_LOG" "/nix/store/bad-apple-sdk"
+assert_not_contains "$SWIFT_ENV_LOG" "/nix/store/bad-developer-dir"
 
 printf 'macOS post-install smoke tests passed\n'

--- a/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
+++ b/swift/fileprovider/Sources/Extension/FileProviderExtension.swift
@@ -119,8 +119,12 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     ) -> Progress {
         // Start with estimated size; updated by callback as real size is known
         let progress = Progress(totalUnitCount: 0)
+        let itemId = itemIdentifier.rawValue
+
+        logger.error("fetchContents start for \(itemId, privacy: .public)")
 
         guard let prov = provider else {
+            logger.error("fetchContents provider unavailable for \(itemId, privacy: .public)")
             completionHandler(nil, nil, NSFileProviderError(.serverUnreachable))
             return progress
         }
@@ -132,7 +136,9 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             let tempDir = FileManager.default.temporaryDirectory
             let tempFile = tempDir.appendingPathComponent(UUID().uuidString)
 
-            let itemId = itemIdentifier.rawValue
+            logger.error(
+                "fetchContents fetching \(itemId, privacy: .public) to \(tempFile.path, privacy: .public)"
+            )
 
             // C callback that updates NSProgress from Rust's chunk loop
             let callback: @convention(c) (UInt64, UInt64, UnsafeRawPointer?) -> Void = {
@@ -160,6 +166,9 @@ class TCFSFileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 let fileSize = (try? FileManager.default.attributesOfItem(
                     atPath: tempFile.path
                 )[.size] as? UInt64) ?? 0
+                logger.error(
+                    "fetchContents completed for \(itemId, privacy: .public): bytes=\(fileSize)"
+                )
 
                 let parentId = TCFSFileProviderExtension.parentIdentifier(forPath: itemId)
                 let item = TCFSFileProviderItem(


### PR DESCRIPTION
## Summary

- Merge current Jesssullivan origin/main into tinyland main while preserving tinyland history.
- Resulting tree is identical to origin/main.
- Brings tinyland up through upstream PR #481 and PR #487.

## Validation

- git diff --stat origin/main HEAD produced no output.
- git diff --check origin/main HEAD passed.