### PR TITLE
build: add Darwin release artifact package target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,3 +6,8 @@ alias(
     name = "darwin_package_fixture_contract",
     actual = "//build/macos:darwin_package_fixture_contract",
 )
+
+alias(
+    name = "darwin_package_release_artifacts_unsigned",
+    actual = "//build/macos:darwin_package_release_artifacts_unsigned",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,3 +6,19 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "1.0.0")
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "tcfs_v0_12_14_macos_aarch64_cli_tar",
+    downloaded_file_path = "tcfs-0.12.14-macos-aarch64.tar.gz",
+    sha256 = "55719e35b624df25386baf63d74247c39a25e857b7c3855cfd4edd6cfae69175",
+    urls = ["https://github.com/Jesssullivan/tummycrypt/releases/download/v0.12.14/tcfs-0.12.14-macos-aarch64.tar.gz"],
+)
+
+http_file(
+    name = "tcfs_v0_12_14_macos_aarch64_fileprovider_zip",
+    downloaded_file_path = "TCFSProvider-0.12.14-macos-aarch64.zip",
+    sha256 = "b5dd29c46073252ba31d4aaa1d07a88a757e33c9a08bef68ea6d3748753c51f4",
+    urls = ["https://github.com/Jesssullivan/tummycrypt/releases/download/v0.12.14/TCFSProvider-0.12.14-macos-aarch64.zip"],
+)

--- a/build/macos/BUILD.bazel
+++ b/build/macos/BUILD.bazel
@@ -76,3 +76,19 @@ tcfs_macos_pkg(
     target_compatible_with = ["@platforms//os:macos"],
     version = "0.12.14",
 )
+
+tcfs_macos_pkg(
+    name = "darwin_package_release_artifacts_unsigned",
+    cli_tar = "@tcfs_v0_12_14_macos_aarch64_cli_tar//file",
+    fileprovider_zip = "@tcfs_v0_12_14_macos_aarch64_fileprovider_zip//file",
+    output_name = "tcfs-0.12.14-macos-aarch64-release-artifacts-unsigned.pkg",
+    tags = [
+        "gloriousflywheel-rbe-contract",
+        "manual",
+        "release-artifact-inputs",
+        "requires-darwin-packaging-tools",
+        "unsigned-package",
+    ],
+    target_compatible_with = ["@platforms//os:macos"],
+    version = "0.12.14",
+)

--- a/docs/ops/darwin-bazel-package-contract.md
+++ b/docs/ops/darwin-bazel-package-contract.md
@@ -4,16 +4,24 @@ TCFS macOS packaging is still owned by the existing release scripts and
 workflows. The Bazel surface added here gives GloriousFlywheel a finite
 downstream target to classify before Darwin RBE dispatch work starts.
 
-## Current Target
+## Current Targets
 
 - `//build/macos:darwin_package_fixture_contract`
 - root alias: `//:darwin_package_fixture_contract`
+- `//build/macos:darwin_package_release_artifacts_unsigned`
+- root alias: `//:darwin_package_release_artifacts_unsigned`
 - rule: `tcfs_macos_pkg` in `build/macos/darwin_pkg.bzl`
 
 The fixture target builds a package from declared fake CLI and FileProvider
 artifacts. It exists to validate the Bazel rule, target shape, and script
 wiring. It is intentionally named as a fixture contract so it cannot be
 mistaken for a production release package.
+
+The release-artifact target builds from the published `v0.12.14` macOS CLI
+tarball and FileProvider zip through pinned `http_file` repositories. It is
+non-fixture, but it is still an unsigned package-assembly target. It does not
+rebuild current source, submit to Apple notarization, staple a ticket, or prove
+Developer ID installer signing custody.
 
 ## Rule Contract
 
@@ -26,16 +34,16 @@ mistaken for a production release package.
 - optional installer signing identity
 
 The rule produces one `.pkg` output and passes
-`TCFS_PKG_STRUCTURE_SMOKE` as a declared tool. It does not discover release
-artifacts, fetch from GitHub releases, notarize, staple, or discover signing
-credentials.
+`TCFS_PKG_STRUCTURE_SMOKE` as a declared tool. It does not discover unpinned
+release artifacts, notarize, staple, or discover signing credentials.
 
 ## Promotion Boundary
 
-Before GloriousFlywheel should classify a TCFS Darwin target as a candidate,
-the next target must use real release artifact labels or a source-built Bazel
-artifact chain. Signed, notarized, or stapled claims still require
-GloriousFlywheel Darwin signing-custody evidence.
+The release-artifact target is the first non-fixture package target, but it is
+not by itself a signed/notarized Darwin RBE candidate. Signed, notarized, or
+stapled claims still require GloriousFlywheel Darwin signing-custody evidence
+and a target or proof lane that runs under executor-side signing custody without
+public/shared action-cache writes for secret-bearing steps.
 
 The existing blocked `//:darwin_package` placeholder should stay blocked until
 a non-fixture production target exists.

--- a/scripts/test-bazel-macos-package-contract.sh
+++ b/scripts/test-bazel-macos-package-contract.sh
@@ -49,9 +49,17 @@ require_contains MODULE.bazel 'module('
 require_contains MODULE.bazel 'name = "tummycrypt"'
 require_contains MODULE.bazel 'version = "0.12.14"'
 require_contains MODULE.bazel 'bazel_dep(name = "platforms", version = "1.0.0")'
+require_contains MODULE.bazel 'use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")'
+require_contains MODULE.bazel 'name = "tcfs_v0_12_14_macos_aarch64_cli_tar"'
+require_contains MODULE.bazel 'downloaded_file_path = "tcfs-0.12.14-macos-aarch64.tar.gz"'
+require_contains MODULE.bazel 'sha256 = "55719e35b624df25386baf63d74247c39a25e857b7c3855cfd4edd6cfae69175"'
+require_contains MODULE.bazel 'name = "tcfs_v0_12_14_macos_aarch64_fileprovider_zip"'
+require_contains MODULE.bazel 'downloaded_file_path = "TCFSProvider-0.12.14-macos-aarch64.zip"'
+require_contains MODULE.bazel 'sha256 = "b5dd29c46073252ba31d4aaa1d07a88a757e33c9a08bef68ea6d3748753c51f4"'
 require_contains .bazelversion '9.1.1'
 
 require_contains BUILD.bazel 'darwin_package_fixture_contract'
+require_contains BUILD.bazel 'darwin_package_release_artifacts_unsigned'
 require_not_contains BUILD.bazel 'name = "darwin_package"'
 
 require_contains build/macos/darwin_pkg.bzl 'ctx.actions.run'
@@ -66,6 +74,11 @@ require_contains build/macos/BUILD.bazel 'name = "darwin_package_fixture_contrac
 require_contains build/macos/BUILD.bazel 'target_compatible_with = ["@platforms//os:macos"]'
 require_contains build/macos/BUILD.bazel '"fixture-only"'
 require_contains build/macos/BUILD.bazel '"gloriousflywheel-rbe-contract"'
+require_contains build/macos/BUILD.bazel 'name = "darwin_package_release_artifacts_unsigned"'
+require_contains build/macos/BUILD.bazel '@tcfs_v0_12_14_macos_aarch64_cli_tar//file'
+require_contains build/macos/BUILD.bazel '@tcfs_v0_12_14_macos_aarch64_fileprovider_zip//file'
+require_contains build/macos/BUILD.bazel '"release-artifact-inputs"'
+require_contains build/macos/BUILD.bazel '"unsigned-package"'
 require_not_contains build/macos/BUILD.bazel 'name = "darwin_package"'
 
 require_contains scripts/BUILD.bazel '"macos-build-pkg.sh"'
@@ -73,6 +86,9 @@ require_contains scripts/BUILD.bazel '"macos-pkg-postinstall.sh"'
 require_contains scripts/BUILD.bazel '"macos-pkg-structure-smoke.sh"'
 
 require_contains docs/ops/darwin-bazel-package-contract.md '//build/macos:darwin_package_fixture_contract'
+require_contains docs/ops/darwin-bazel-package-contract.md '//build/macos:darwin_package_release_artifacts_unsigned'
+require_contains docs/ops/darwin-bazel-package-contract.md "non-fixture"
+require_contains docs/ops/darwin-bazel-package-contract.md "unsigned package-assembly target"
 require_contains docs/ops/darwin-bazel-package-contract.md "The existing blocked \`//:darwin_package\` placeholder should stay blocked"
 
 help_output="$("$REPO_ROOT/scripts/macos-build-pkg.sh" --help)"


### PR DESCRIPTION
## Summary

- Adds pinned Bzlmod `http_file` inputs for the published `v0.12.14` macOS CLI tarball and FileProvider zip.
- Adds `//build/macos:darwin_package_release_artifacts_unsigned` plus root alias `//:darwin_package_release_artifacts_unsigned`.
- Documents that this is a real non-fixture package-assembly target, but still unsigned and not a Developer ID/notary/staple proof.
- Extends the Bazel macOS package contract regression test for the release-artifact target and pinned digests.

## Validation

- `bash -n scripts/test-bazel-macos-package-contract.sh`
- `shellcheck scripts/test-bazel-macos-package-contract.sh`
- `bash scripts/test-bazel-macos-package-contract.sh`
- `task lazy:test-bazel-macos-package-contract`
- `bazel mod deps --lockfile_mode=error --noshow_progress`
- `bazel query //build/macos:darwin_package_release_artifacts_unsigned --noshow_progress`
- `bazel query //:darwin_package_release_artifacts_unsigned --noshow_progress`
- `bazel build //build/macos:darwin_package_release_artifacts_unsigned --noshow_progress`
- `git diff --check`

## Boundary

The Bazel build produced `bazel-bin/build/macos/tcfs-0.12.14-macos-aarch64-release-artifacts-unsigned.pkg` and package structure smoke passed. This is local package assembly from pinned release assets only. It is not RBE evidence, not current-source build proof, and not signed/notarized/stapled package proof.
