### PR TITLE
codex: sync origin/main -> tinyland/main (repo-roam + per-device crypto; deny.toml + Taskfile union, 2026-06-08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Current release-proof posture is tracked in `docs/release/evidence/` and
 `docs/ops/product-reality-and-priority.md`; older entries below may describe
 historical release intent rather than the current supported/proven surface.
 
+## [Unreleased]
+
+### Changed
+
+- **Per-device file-key wrapping is now a tri-state `crypto.wrap_mode`**
+  (TIN-1417, replaces the `crypto.per_device_wrapping` boolean). Values:
+  `master` (DEFAULT — shared-master wrap, byte-identical to the previous
+  default), `dual` (EXPAND/transitional — emits BOTH the master wrap and
+  per-device wraps; manifest stays v2 and back-compatible), and `per_device`
+  (CONTRACT — emits per-device wraps ONLY, drops the master wrap for true
+  revocation, and bumps the manifest to v3 so pre-per-device binaries fail
+  CLOSED). Back-compat: a legacy `crypto.per_device_wrapping = true` config
+  deserializes to `dual` (keeps the master fallback); `false`/absent maps to
+  `master`. A present `wrap_mode` is canonical and wins. The daemon REFUSES to
+  drop the master wrap (`per_device`) until a roll-call probe confirms every
+  active, non-revoked device carries a real age recipient; otherwise it falls
+  back to `dual` and warns loudly. Default remains `master`, so existing fleets
+  are unaffected until the migration is explicitly enabled.
+
 ## [0.12.14] - 2026-06-03
 
 First finalized release of the 0.12.13→0.12.14 line (0.12.13 shipped only as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,6 +1439,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
@@ -1450,9 +1451,11 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
  "signature",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5393,6 +5396,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "blake3",
+ "ed25519-dalek",
+ "hkdf",
  "hostname",
  "keepass",
  "keyring",
@@ -5403,6 +5408,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "sha2",
  "tcfs-core",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ aes-siv = { version = "0.7" }
 hkdf = { version = "0.12" }
 sha2 = { version = "0.10" }
 rand = { version = "0.8" }
+# Ed25519 signing for the device registry (TIN-1417 B4). Already present in the
+# lockfile transitively (async-nats -> nkeys); pinned here for direct use.
+ed25519-dalek = { version = "2" }
 bip39 = { version = "2" }
 keyring = { version = "3" }
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -107,8 +107,8 @@ tasks:
   lazy:check:
     desc: Run lazy hydration harness/static regression checks
     cmds:
-      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
-      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - bash -n scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
+      - shellcheck scripts/lazy-hydration-linux-demo.sh scripts/lazy-hydration-linux-lifecycle-demo.sh scripts/test-lazy-hydration-linux-lifecycle-demo.sh scripts/lazy-hydration-mounted-smoke.sh scripts/test-lazy-hydration-mounted-smoke.sh scripts/lazy-hydration-desktop-honey-demo.sh scripts/test-lazy-hydration-desktop-honey-demo.sh scripts/fleet-parity-pilot-demo.sh scripts/test-fleet-parity-pilot-demo.sh scripts/neo-honey-unsynced-rehydrate-demo.sh scripts/test-neo-honey-unsynced-rehydrate-demo.sh scripts/neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/test-neo-honey-reverse-unsynced-rehydrate-demo.sh scripts/neo-mounted-reverse-read-demo.sh scripts/test-neo-mounted-reverse-read-demo.sh scripts/neo-honey-delete-rename-unsynced-demo.sh scripts/test-neo-honey-delete-rename-unsynced-demo.sh scripts/neo-honey-conflict-demo.sh scripts/test-neo-honey-conflict-demo.sh scripts/git-repo-canary.sh scripts/test-git-repo-canary.sh scripts/git-repo-restore-proof.sh scripts/test-git-repo-restore-proof.sh scripts/git-roam-daily-driver-harness.sh scripts/test-git-roam-daily-driver-harness.sh scripts/tcfs-symlink-package-probe.sh scripts/test-tcfs-symlink-package-probe.sh scripts/home-canary-linux-xr-shadow.sh scripts/test-home-canary-linux-xr-shadow.sh scripts/home-canary-linux-xr-storage-posture.sh scripts/test-home-canary-linux-xr-storage-posture.sh scripts/macos-fileprovider-neo-cleanup-packet.sh scripts/test-macos-fileprovider-neo-cleanup-packet.sh scripts/macos-developer-cert-match.sh scripts/macos-fileprovider-profile-inventory.sh scripts/test-macos-fileprovider-profile-inventory.sh scripts/macos-fileprovider-preflight.sh scripts/test-macos-fileprovider-preflight.sh scripts/macos-tcfs-rollout-readiness.sh scripts/test-macos-tcfs-rollout-readiness.sh scripts/macos-postinstall-smoke.sh scripts/macos-build-pkg.sh scripts/macos-pkg-postinstall.sh scripts/macos-pkg-structure-smoke.sh scripts/macos-fileprovider-testing-mode-dispatch.sh scripts/macos-fileprovider-lab-gatekeeper-override.sh scripts/macos-codesign-p12-probe.sh scripts/test-macos-build-pkg.sh scripts/test-macos-postinstall-smoke.sh scripts/test-macos-pkg-structure-smoke.sh scripts/test-macos-fileprovider-pkg-notarization-proof.sh scripts/test-macos-fileprovider-testing-mode-dispatch.sh scripts/test-macos-fileprovider-lab-gatekeeper-override.sh scripts/test-asc-fileprovider-lab-provision.sh scripts/test-fileprovider-provision-config.sh scripts/test-fileprovider-surface-contract.sh scripts/test-release-workflow-fileprovider.sh scripts/test-release-workflow-container.sh swift/fileprovider/provision-config.sh swift/fileprovider/build.sh
       - python3 -m py_compile scripts/asc-fileprovider-lab-provision.py scripts/tcfs-smoke-endpoint-preflight.py scripts/test-tcfs-smoke-endpoint-preflight.py scripts/large-workdir-inventory.py scripts/test-large-workdir-inventory.py
       - task: lazy:test-linux-lifecycle-demo
       - task: lazy:test-mounted-smoke
@@ -121,6 +121,7 @@ tasks:
       - task: lazy:test-neo-honey-conflict
       - task: lazy:test-git-repo-canary
       - task: lazy:test-git-repo-restore-proof
+      - task: lazy:test-git-roam-daily-driver
       - task: lazy:test-tcfs-symlink-package-probe
       - task: lazy:test-home-canary-linux-xr-shadow
       - task: lazy:test-home-canary-linux-xr-storage-posture
@@ -674,6 +675,46 @@ tasks:
     desc: Regression-test the git repo fresh-tree restore proof helper
     cmds:
       - bash scripts/test-git-repo-restore-proof.sh
+
+  lazy:git-roam-daily-driver-plan:
+    desc: "Plan-only evidence packet for the ~/git daily-driver roam story"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          args=()
+
+          if [[ -n "${REPO:-}" ]]; then
+            args+=(--repo "$REPO")
+          fi
+          if [[ -n "${AGENT_ROOT:-}" ]]; then
+            args+=(--agent-root "$AGENT_ROOT")
+          fi
+          if [[ -n "${NAME:-}" ]]; then
+            args+=(--name "$NAME")
+          fi
+          if [[ -n "${ORIGIN_HOST:-}" ]]; then
+            args+=(--origin-host "$ORIGIN_HOST")
+          fi
+          if [[ -n "${CONTINUATION_HOST:-}" ]]; then
+            args+=(--continuation-host "$CONTINUATION_HOST")
+          fi
+          if [[ -n "${THIRD_HOST:-}" ]]; then
+            args+=(--third-host "$THIRD_HOST")
+          fi
+          if [[ -n "${REMOTE_PREFIX:-}" ]]; then
+            args+=(--remote-prefix "$REMOTE_PREFIX")
+          fi
+          if [[ -n "${EVIDENCE_DIR:-}" ]]; then
+            args+=(--evidence-dir "$EVIDENCE_DIR")
+          fi
+
+          scripts/git-roam-daily-driver-harness.sh "${args[@]}"
+          EOF
+
+  lazy:test-git-roam-daily-driver:
+    desc: Regression-test the git roam daily-driver plan-only harness
+    cmds:
+      - bash scripts/test-git-roam-daily-driver-harness.sh
 
   lazy:storage-large-restore-slo:
     desc: "Evaluate a storage large-restore packet against optional SLO budgets"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -707,6 +707,12 @@ tasks:
           if [[ -n "${EVIDENCE_DIR:-}" ]]; then
             args+=(--evidence-dir "$EVIDENCE_DIR")
           fi
+          if [[ -n "${MAX_HASH_FILES:-}" ]]; then
+            args+=(--max-hash-files "$MAX_HASH_FILES")
+          fi
+          if [[ -n "${MAX_HASH_FILE_BYTES:-}" ]]; then
+            args+=(--max-hash-file-bytes "$MAX_HASH_FILE_BYTES")
+          fi
 
           scripts/git-roam-daily-driver-harness.sh "${args[@]}"
           EOF

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -629,6 +629,42 @@ tasks:
     cmds:
       - bash scripts/test-git-repo-canary.sh
 
+  lazy:dev-env-fingerprint:
+    desc: "Git-aware dev-env zero-diff fingerprint (G5/TIN-1620 precision layer over T2/T3/T8/T10)"
+    cmds:
+      - cmd: |
+          bash -euo pipefail <<'EOF'
+          mode="${MODE:-self-test}"
+          case "$mode" in
+            self-test)
+              scripts/repo-roam-fingerprint.sh self-test "${OUT_DIR:-}"
+              ;;
+            capture)
+              : "${REPO:?set REPO=<git worktree> for MODE=capture}"
+              : "${OUT_DIR:?set OUT_DIR=<evidence dir> for MODE=capture}"
+              scripts/repo-roam-fingerprint.sh capture "$REPO" "$OUT_DIR"
+              ;;
+            compare)
+              : "${DIR_A:?set DIR_A=<source fingerprint> for MODE=compare}"
+              : "${DIR_B:?set DIR_B=<rehydrated fingerprint> for MODE=compare}"
+              scripts/repo-roam-fingerprint.sh compare "$DIR_A" "$DIR_B"
+              ;;
+            seed-canary)
+              : "${OUT_DIR:?set OUT_DIR=<throwaway dir> for MODE=seed-canary}"
+              scripts/repo-roam-fingerprint.sh seed-canary "$OUT_DIR"
+              ;;
+            *)
+              echo "MODE must be self-test|capture|compare|seed-canary" >&2
+              exit 2
+              ;;
+          esac
+          EOF
+
+  lazy:test-dev-env-fingerprint:
+    desc: Regression-test the git-aware dev-env fingerprint tool
+    cmds:
+      - bash scripts/test-repo-roam-fingerprint.sh
+
   lazy:git-repo-restore-proof:
     desc: "Fresh-tree restore proof for an existing pushed git repo canary packet"
     cmds:

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -740,7 +740,7 @@ async fn main() -> Result<()> {
                 sync_remote,
             } => cmd_device_enroll(&config, name, repair_placeholder, sync_remote).await,
             DeviceAction::List => cmd_device_list(),
-            DeviceAction::Revoke { name } => cmd_device_revoke(&name),
+            DeviceAction::Revoke { name } => cmd_device_revoke(&config, &name),
             DeviceAction::Status => cmd_device_status(),
             DeviceAction::Invite { expiry_hours, qr } => {
                 cmd_device_invite(&config, expiry_hours, qr).await
@@ -963,7 +963,10 @@ fn load_device_id(config: &tcfs_core::config::TcfsConfig) -> String {
                     let new_id = registry
                         .backfill_device_id(&device_name)
                         .expect("backfill_device_id with valid device name");
-                    if let Err(e) = registry.save(&registry_path) {
+                    // TIN-1417 B4: keep the signature valid after a backfill write.
+                    if let Err(e) =
+                        save_registry_signed_or_warn(&mut registry, &registry_path, config)
+                    {
                         eprintln!("warning: failed to save backfilled device registry: {e}");
                     } else {
                         eprintln!(
@@ -1130,11 +1133,24 @@ fn build_encryption_context(
         .device_identity
         .clone()
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: build recipients only from a signature-VERIFIED registry;
+    // an unsigned/tampered registry falls back to the shared master wrap.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
+                 per-device recipients from an unverified registry — using master wrap."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }
@@ -3649,7 +3665,9 @@ async fn cmd_init(config: &tcfs_core::config::TcfsConfig, options: InitOptions<'
     let (device_id, device_key) = registry.enroll_local(&device_name, None);
     let device_key_path = tcfs_secrets::device::device_secret_key_path(&registry_path, &device_id);
     tcfs_secrets::device::save_device_secret_key(&device_key_path, &device_key.secret_key, false)?;
-    registry.save(&registry_path)?;
+    // TIN-1417 B4: sign the registry with the freshly written master key so the
+    // very first registry on disk is signed (no migration window for new setups).
+    registry.save_signed(&registry_path, master_key.as_bytes())?;
 
     let init_config = build_init_config(config, &master_key_path, &registry_path, &device_name);
     if !skip_config {
@@ -4169,12 +4187,14 @@ fn cmd_device_list() -> Result<()> {
 
 // ── `tcfs device revoke` ─────────────────────────────────────────────────────
 
-fn cmd_device_revoke(name: &str) -> Result<()> {
+fn cmd_device_revoke(config: &tcfs_core::config::TcfsConfig, name: &str) -> Result<()> {
     let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
 
     if registry.revoke(name) {
-        registry.save(&registry_path)?;
+        // TIN-1417 B4: re-sign so the revocation is recorded in a signed envelope
+        // (revoked + revoked_at), making per-device revocation trustworthy.
+        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
         println!("Revoked device: {}", name);
     } else {
         anyhow::bail!("Device '{}' not found", name);
@@ -4236,15 +4256,38 @@ async fn cmd_device_enroll(
         enrolled_or_repaired = true;
     }
 
-    registry.save(&registry_path)?;
+    save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
 
     if sync_remote {
         let op = build_operator(config).await?;
         let meta_prefix = config.storage.resolved_prefix();
-        let remote = tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?;
+        // TIN-1417 B4: verify the remote registry before merging so a tampered
+        // remote registry is rejected rather than silently merged into ours.
+        let remote = match master_key_for_registry_signing(config) {
+            Some(mk) => {
+                let (remote, _trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+                    &op,
+                    meta_prefix,
+                    mk.as_bytes(),
+                )
+                .await?;
+                remote
+            }
+            None => tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?,
+        };
         merge_device_registry(&mut registry, &remote)?;
-        tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix).await?;
-        registry.save(&registry_path)?;
+        match master_key_for_registry_signing(config) {
+            Some(mk) => {
+                registry
+                    .sync_to_remote_signed(&op, meta_prefix, mk.as_bytes())
+                    .await?
+            }
+            None => {
+                tcfs_secrets::device::DeviceRegistry::sync_to_remote(&registry, &op, meta_prefix)
+                    .await?
+            }
+        }
+        save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
     }
 
     if enrolled_or_repaired {
@@ -4954,6 +4997,39 @@ fn read_rotation_state(path: &Path) -> Result<KeyRotationState> {
     let data = std::fs::read(path)
         .with_context(|| format!("reading key rotation state: {}", path.display()))?;
     serde_json::from_slice(&data).context("parsing key rotation state")
+}
+
+/// Best-effort load of the master key for *signing the device registry*
+/// (TIN-1417 B4). Returns `None` (with a loud warning) when no master key file is
+/// configured/readable, so registry mutations still succeed but leave the
+/// registry unsigned for the migration window instead of hard-failing.
+fn master_key_for_registry_signing(
+    config: &tcfs_core::config::TcfsConfig,
+) -> Option<tcfs_crypto::MasterKey> {
+    let path = config.crypto.master_key_file.as_ref()?;
+    match read_master_key(path) {
+        Ok(k) => Some(k),
+        Err(e) => {
+            tracing::warn!(
+                "TIN-1417 B4: cannot read master key for registry signing ({e}); the device \
+                 registry will be written UNSIGNED. Per-device wrapping will refuse to trust it."
+            );
+            None
+        }
+    }
+}
+
+/// Sign (if a master key is available) and save the registry to disk. Falls back
+/// to an unsigned save with a warning when no master key is configured.
+fn save_registry_signed_or_warn(
+    registry: &mut tcfs_secrets::device::DeviceRegistry,
+    path: &Path,
+    config: &tcfs_core::config::TcfsConfig,
+) -> Result<()> {
+    match master_key_for_registry_signing(config) {
+        Some(mk) => registry.save_signed(path, mk.as_bytes()),
+        None => registry.save(path),
+    }
 }
 
 fn read_master_key(path: &Path) -> Result<tcfs_crypto::MasterKey> {

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -1100,20 +1100,29 @@ fn resolve_sync_status_lookup_path(path: &Path) -> Result<PathBuf> {
     std::fs::canonicalize(path).map_err(Into::into)
 }
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (logging why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
+///
+/// Mirrors the daemon's `build_encryption_context`:
+/// - `Master` (default): legacy shared-master wrap (byte-identical to before).
+/// - `Dual`: master wrap + per-device wraps (requires a real recipient set).
+/// - `PerDevice`: per-device-only wrap, gated behind a roll-call probe — refused
+///   (and downgraded to `Dual` + a loud warning) unless EVERY active device has
+///   a real age recipient.
+///
+/// Falls back to master (logging why) whenever the registry can't be loaded, has
+/// no real recipients, or this device's age secret is missing — never producing
+/// content this device cannot read back.
 fn build_encryption_context(
     config: &tcfs_core::config::TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
     let registry_path = config
@@ -1124,7 +1133,9 @@ fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
@@ -1138,7 +1149,7 @@ fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
@@ -1150,12 +1161,38 @@ fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
-    base.with_device_wrapping(recipients, Some(identity))
+    let effective = resolve_wrap_mode_with_roll_call(requested, &registry);
+    base.with_wrap_mode(effective, recipients, Some(identity))
+}
+
+/// Apply the roll-call gate to a requested wrap mode (CLI mirror of the daemon's
+/// gate). `PerDevice` downgrades to `Dual` (with a loud warning) unless every
+/// active device carries a real age recipient.
+fn resolve_wrap_mode_with_roll_call(
+    requested: tcfs_core::config::WrapMode,
+    registry: &tcfs_secrets::device::DeviceRegistry,
+) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if requested != WrapMode::PerDevice {
+        return requested;
+    }
+    let roll_call = registry.roll_call();
+    if roll_call.all_capable() {
+        return WrapMode::PerDevice;
+    }
+    tracing::warn!(
+        active = roll_call.active,
+        capable = roll_call.capable,
+        blockers = ?roll_call.incapable_devices,
+        "wrap_mode=PerDevice REFUSED by roll-call gate: not every active device has a real \
+         age recipient; falling back to Dual (keeping the master wrap)."
+    );
+    WrapMode::Dual
 }
 
 // ── `tcfs push` ───────────────────────────────────────────────────────────────
@@ -3896,27 +3933,28 @@ struct FileProviderInitConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     daemon_socket: Option<String>,
     master_key_file: String,
-    /// Per-device file-key wrapping (TIN-1417 / Track B1). Mirrors
-    /// `crypto.per_device_wrapping` from the active config. The FileProvider
-    /// extension reads this key to decide whether to build a device-aware
-    /// `EncryptionContext` (see `tcfs-file-provider` `device_ctx`). Omitted
-    /// from the rendered JSON when false so the default-off output stays
-    /// byte-identical to the legacy master-only bootstrap.
-    #[serde(skip_serializing_if = "is_false")]
-    per_device_wrapping: bool,
+    /// File-key wrap mode (TIN-1417). Mirrors `crypto.wrap_mode` from the active
+    /// config. The FileProvider extension reads this key to decide whether to
+    /// build a device-aware `EncryptionContext` (see `tcfs-file-provider`
+    /// `device_ctx`). Omitted from the rendered JSON when `Master` (the default)
+    /// so the default-off output stays byte-identical to the legacy master-only
+    /// bootstrap.
+    #[serde(skip_serializing_if = "is_master_wrap_mode")]
+    wrap_mode: tcfs_core::config::WrapMode,
     /// Path to the device registry (`devices.json`) the FileProvider must read
     /// to resolve active age recipients + this device's secret
-    /// (`device-<id>.age` alongside it). Only emitted when
-    /// `per_device_wrapping` is true; the extension otherwise falls back to its
-    /// own default registry path.
+    /// (`device-<id>.age` alongside it). Only emitted when `wrap_mode` is not
+    /// `Master`; the extension otherwise falls back to its own default registry
+    /// path.
     #[serde(skip_serializing_if = "Option::is_none")]
     device_registry_path: Option<String>,
 }
 
-/// `skip_serializing_if` predicate so `per_device_wrapping` is omitted from the
-/// rendered FileProvider JSON when off, keeping default-off output unchanged.
-fn is_false(value: &bool) -> bool {
-    !*value
+/// `skip_serializing_if` predicate so `wrap_mode` is omitted from the rendered
+/// FileProvider JSON when it is the default `Master`, keeping default-off output
+/// byte-identical to the legacy bootstrap.
+fn is_master_wrap_mode(value: &tcfs_core::config::WrapMode) -> bool {
+    *value == tcfs_core::config::WrapMode::Master
 }
 
 fn build_fileprovider_init_config(
@@ -3925,17 +3963,19 @@ fn build_fileprovider_init_config(
     master_key_path: &Path,
     device_id: &str,
 ) -> FileProviderInitConfig {
-    let per_device_wrapping = config.crypto.per_device_wrapping;
-    // Only surface the device registry path when per-device wrapping is on, so
-    // the default-off rendered JSON is byte-identical to the legacy bootstrap.
-    let device_registry_path = if per_device_wrapping {
+    use tcfs_core::config::WrapMode;
+    let wrap_mode = config.crypto.wrap_mode;
+    // Only surface the device registry path when per-device wrapping is involved
+    // (Dual/PerDevice), so the default-off rendered JSON is byte-identical to the
+    // legacy bootstrap.
+    let device_registry_path = if wrap_mode == WrapMode::Master {
+        None
+    } else {
         Some(
             resolve_fileprovider_registry_path(config)
                 .to_string_lossy()
                 .into_owned(),
         )
-    } else {
-        None
     };
     FileProviderInitConfig {
         s3_endpoint: config.storage.endpoint.clone(),
@@ -3951,7 +3991,7 @@ fn build_fileprovider_init_config(
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned()),
         master_key_file: master_key_path.to_string_lossy().into_owned(),
-        per_device_wrapping,
+        wrap_mode,
         device_registry_path,
     }
 }
@@ -5911,12 +5951,12 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_omits_per_device_keys_when_disabled() {
-        // Default-off must stay byte-identical to the legacy master-only
-        // bootstrap: the per-device keys are absent from the rendered JSON.
+        // Default-off (wrap_mode = Master) must stay byte-identical to the legacy
+        // master-only bootstrap: the per-device keys are absent from the JSON.
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        assert!(!config.crypto.per_device_wrapping);
-        // Even with a registry path configured, off => not emitted.
+        assert_eq!(config.crypto.wrap_mode, tcfs_core::config::WrapMode::Master);
+        // Even with a registry path configured, Master => not emitted.
         config.sync.device_identity = Some(dir.path().join("devices.json"));
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5928,14 +5968,18 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(!rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::Master);
         assert_eq!(rendered.device_registry_path, None);
 
         let json = serde_json::to_value(&rendered).unwrap();
         let obj = json.as_object().unwrap();
         assert!(
+            !obj.contains_key("wrap_mode"),
+            "wrap_mode must be omitted when Master (byte-identical default)"
+        );
+        assert!(
             !obj.contains_key("per_device_wrapping"),
-            "per_device_wrapping must be omitted when off (byte-identical default)"
+            "legacy per_device_wrapping key must never be emitted"
         );
         assert!(
             !obj.contains_key("device_registry_path"),
@@ -5945,13 +5989,13 @@ mod tests {
 
     #[test]
     fn build_fileprovider_init_config_emits_per_device_keys_when_enabled() {
-        // When per-device wrapping is on, the rendered FileProvider config must
-        // carry the keys PR #492's read path consumes: `per_device_wrapping`
-        // (true) and `device_registry_path` (the configured registry).
+        // When wrap_mode is non-Master, the rendered FileProvider config must
+        // carry the keys the read path consumes: `wrap_mode` and
+        // `device_registry_path` (the configured registry).
         let dir = tempfile::tempdir().unwrap();
         let registry_path = dir.path().join("devices.json");
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::PerDevice;
         config.sync.device_identity = Some(registry_path.clone());
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5963,17 +6007,46 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::PerDevice);
         assert_eq!(
             rendered.device_registry_path.as_deref(),
             Some(registry_path.to_string_lossy().as_ref())
         );
 
         let json = serde_json::to_value(&rendered).unwrap();
-        assert_eq!(json["per_device_wrapping"], serde_json::Value::Bool(true));
+        assert_eq!(
+            json["wrap_mode"],
+            serde_json::Value::String("per_device".to_string())
+        );
         assert_eq!(
             json["device_registry_path"].as_str(),
             Some(registry_path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn build_fileprovider_init_config_emits_dual_wrap_mode() {
+        // Dual must also surface the registry path and emit wrap_mode = "dual".
+        let dir = tempfile::tempdir().unwrap();
+        let registry_path = dir.path().join("devices.json");
+        let mut config = test_config(dir.path());
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::Dual;
+        config.sync.device_identity = Some(registry_path.clone());
+
+        let s3 = tcfs_secrets::S3Credentials {
+            access_key_id: "access-key".into(),
+            secret_access_key: secrecy::SecretString::from("secret-key".to_string()),
+            endpoint: config.storage.endpoint.clone(),
+            region: config.storage.region.clone(),
+        };
+        let master_key_path = dir.path().join("master.key");
+        let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
+
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::Dual);
+        let json = serde_json::to_value(&rendered).unwrap();
+        assert_eq!(
+            json["wrap_mode"],
+            serde_json::Value::String("dual".to_string())
         );
     }
 
@@ -5983,7 +6056,7 @@ mod tests {
         // default registry path (matching the extension's own fallback).
         let dir = tempfile::tempdir().unwrap();
         let mut config = test_config(dir.path());
-        config.crypto.per_device_wrapping = true;
+        config.crypto.wrap_mode = tcfs_core::config::WrapMode::PerDevice;
         config.sync.device_identity = None;
 
         let s3 = tcfs_secrets::S3Credentials {
@@ -5995,7 +6068,7 @@ mod tests {
         let master_key_path = dir.path().join("master.key");
         let rendered = build_fileprovider_init_config(&config, &s3, &master_key_path, "device-1");
 
-        assert!(rendered.per_device_wrapping);
+        assert_eq!(rendered.wrap_mode, tcfs_core::config::WrapMode::PerDevice);
         assert_eq!(
             rendered.device_registry_path,
             Some(

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -505,6 +505,14 @@ enum KeyAction {
         /// effect without `--rotate-keys`.
         #[arg(long)]
         non_interactive: bool,
+        /// GC orphaned old chunks IMMEDIATELY (grace=0) instead of honoring the
+        /// configured `orphan_chunk_cleanup_grace_secs`. Reference-safe either
+        /// way (only chunks unreferenced by ANY live manifest are swept), but
+        /// the default grace protects a concurrent reader in a multi-writer
+        /// fleet that still holds an old chunk address. Use only when you are
+        /// certain no reader is mid-flight.
+        #[arg(long)]
+        gc_immediate: bool,
     },
 }
 
@@ -846,7 +854,18 @@ async fn main() -> Result<()> {
                 rotate_keys,
                 resume,
                 non_interactive,
-            } => cmd_key_rotate(&config, &prefix, rotate_keys, resume, non_interactive).await,
+                gc_immediate,
+            } => {
+                cmd_key_rotate(
+                    &config,
+                    &prefix,
+                    rotate_keys,
+                    resume,
+                    non_interactive,
+                    gc_immediate,
+                )
+                .await
+            }
         },
         Commands::Reconcile {
             path,
@@ -5950,12 +5969,58 @@ async fn list_scoped_manifests(
     Ok(paths)
 }
 
+/// Whether the closing message after a rotation may truthfully claim per-device
+/// forward secrecy.
+///
+/// Forward secrecy from re-keying only holds when the re-wrapped content carries
+/// NO path back to a shared, unchanged secret. That is exactly
+/// [`WrapMode::PerDevice`] with a non-empty recipient set (manifest v3, no master
+/// wrap). Under the DEFAULT [`WrapMode::Master`] (and [`WrapMode::Dual`]) the
+/// re-keyed FileKey is re-wrapped to the UNCHANGED shared master key, so a
+/// revoked master-key holder STILL decrypts the re-keyed content — claiming
+/// forward secrecy there would be false and dangerous.
+fn rotation_grants_forward_secrecy(ctx: &tcfs_sync::engine::EncryptionContext) -> bool {
+    use tcfs_sync::engine::WrapMode;
+    ctx.wrap_mode == WrapMode::PerDevice && !ctx.device_recipients.is_empty()
+}
+
+/// The closing forward-secrecy summary for a completed rotation, rendered as
+/// lines to print. Gated on [`rotation_grants_forward_secrecy`]: only the
+/// per-device path earns the reassurance; Master/Dual gets a LOUD warning that
+/// no per-device forward secrecy was gained.
+fn forward_secrecy_summary_lines(ctx: &tcfs_sync::engine::EncryptionContext) -> Vec<String> {
+    if rotation_grants_forward_secrecy(ctx) {
+        vec![
+            "Forward secrecy: devices absent from the current recipient set can no longer \
+             decrypt the re-keyed content (per-device wrap, no master wrap). (They may still \
+             hold content they previously pulled.)"
+                .to_string(),
+        ]
+    } else {
+        vec![
+            "WARNING: NO per-device forward secrecy was gained by this rotation.".to_string(),
+            format!(
+                "  wrap_mode={:?}: the re-keyed content was re-wrapped to the UNCHANGED shared \
+                 master key.",
+                ctx.wrap_mode
+            ),
+            "  A revoked device that still holds the master key can STILL decrypt the re-keyed \
+             content."
+                .to_string(),
+            "  Per-device forward secrecy requires wrap_mode=PerDevice (per-device-only wraps, \
+             no master wrap) with a real recipient set."
+                .to_string(),
+        ]
+    }
+}
+
 async fn cmd_key_rotate(
     config: &tcfs_core::config::TcfsConfig,
     scope: &str,
     rotate_keys: bool,
     resume: bool,
     non_interactive: bool,
+    gc_immediate: bool,
 ) -> Result<()> {
     let storage_prefix = config.storage.resolved_prefix().to_string();
     let scope_clean = scope.trim_matches('/');
@@ -6016,8 +6081,10 @@ async fn cmd_key_rotate(
     if !rotate_keys {
         println!();
         println!(
-            "Dry run -- no changes made. Re-run with --rotate-keys to perform the rotation \
-             (re-chunk + re-encrypt + re-wrap + GC)."
+            "Dry run -- no changes made. Re-run with --rotate-keys to perform the rotation. \
+             Content is re-encrypted under fresh FileKeys per the existing index (no \
+             re-chunking; file_hash/file_id stay valid), re-wrapped to the current recipient \
+             set, and the orphaned old chunks are GC'd."
         );
         return Ok(());
     }
@@ -6106,26 +6173,55 @@ async fn cmd_key_rotate(
     state.all_published = true;
     write_scoped_rotation_state(&state_path, &state)?;
 
+    // GC grace: default to the configured orphan_chunk_cleanup_grace_secs so a
+    // concurrent reader in a multi-writer fleet that still holds an old chunk
+    // address won't 404 mid-flight. `--gc-immediate` opts into grace=0 (the old
+    // hardcoded behavior). Either way GC is reference-safe: only chunks
+    // unreferenced by ANY live manifest are eligible.
+    let gc_grace = if gc_immediate {
+        Duration::from_secs(0)
+    } else {
+        Duration::from_secs(config.sync.orphan_chunk_cleanup_grace_secs)
+    };
     println!();
-    println!(
-        "GC: sweeping chunks no longer referenced by ANY live manifest under {remote_prefix} ..."
-    );
+    if gc_immediate {
+        println!(
+            "GC: sweeping chunks no longer referenced by ANY live manifest under {remote_prefix} \
+             (grace=0, immediate) ..."
+        );
+    } else {
+        println!(
+            "GC: sweeping chunks no longer referenced by ANY live manifest under {remote_prefix} \
+             (grace={}s; older orphans only — pass --gc-immediate for grace=0) ...",
+            config.sync.orphan_chunk_cleanup_grace_secs
+        );
+    }
     let cleanup = tcfs_sync::reconcile::cleanup_orphaned_chunks(
         &op,
         &remote_prefix,
-        Duration::from_secs(0),
+        gc_grace,
         SystemTime::now(),
     )
     .await
     .context("GC of orphaned chunks after rotation")?;
 
+    let deferred_orphans =
+        cleanup.skipped_within_grace.len() + cleanup.skipped_missing_last_modified.len();
     println!(
-        "  GC: {} orphaned, {} deleted, {} referenced (kept), {} errors",
+        "  GC: {} orphaned, {} deleted, {} deferred (within grace), {} referenced (kept), {} \
+         errors",
         cleanup.orphaned_chunks_found,
         cleanup.deleted_chunks.len(),
+        deferred_orphans,
         cleanup.referenced_chunks,
         cleanup.delete_errors.len()
     );
+    if deferred_orphans > 0 && !gc_immediate {
+        println!(
+            "       {deferred_orphans} orphaned chunk(s) are within the grace window and will be \
+             swept by a later GC (or now with --gc-immediate)."
+        );
+    }
     for (hash, err) in &cleanup.delete_errors {
         eprintln!("    GC error: {hash}: {err}");
     }
@@ -6157,10 +6253,9 @@ async fn cmd_key_rotate(
         cleanup.deleted_chunks.len()
     );
     println!();
-    println!(
-        "Forward secrecy: devices absent from the current recipient set can no longer decrypt the \
-         re-keyed content. (They may still hold content they previously pulled.)"
-    );
+    for line in forward_secrecy_summary_lines(&ctx) {
+        println!("{line}");
+    }
 
     Ok(())
 }
@@ -8792,5 +8887,142 @@ enabled = false
             "exactly one per-device-only manifest (NOT counted as plaintext)"
         );
         assert_eq!(state.rotated_manifests, 1, "the master-wrapped one rotated");
+    }
+
+    // ── TIN-1899 must-fix: forward-secrecy messaging is gated on wrap_mode ──
+
+    /// Build a DEFAULT Master-wrap context: this is what `cmd_key_rotate`
+    /// constructs via `build_encryption_context` when `crypto.wrap_mode` is the
+    /// default `Master`. Re-keyed content is re-wrapped to the unchanged shared
+    /// master key — NO per-device forward secrecy.
+    fn master_ctx(master: &tcfs_crypto::MasterKey) -> EncryptionContext {
+        EncryptionContext::new(master.clone())
+    }
+
+    /// Build a Dual context: master wrap + per-device wraps. The master wrap is
+    /// retained, so a revoked master-key holder still decrypts — also NO
+    /// per-device forward secrecy.
+    fn dual_ctx(
+        master: &tcfs_crypto::MasterKey,
+        recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+        identity: DeviceUnwrapIdentity,
+    ) -> EncryptionContext {
+        EncryptionContext::new(master.clone()).with_wrap_mode(
+            EngWrapMode::Dual,
+            recipients,
+            Some(identity),
+        )
+    }
+
+    /// The must-fix: under DEFAULT Master wrap, `cmd_key_rotate`'s closing
+    /// summary must NOT claim forward secrecy. It must instead emit the LOUD
+    /// warning that re-keyed content was re-wrapped to the UNCHANGED shared
+    /// master key and a revoked master-key holder still decrypts. This drives the
+    /// exact decision logic `cmd_key_rotate` prints (see
+    /// `forward_secrecy_summary_lines`).
+    #[test]
+    fn master_wrap_rotation_warns_no_forward_secrecy() {
+        let master = master_key(0x42);
+        let ctx = master_ctx(&master);
+
+        assert!(
+            !rotation_grants_forward_secrecy(&ctx),
+            "Master wrap must NOT be reported as granting forward secrecy"
+        );
+
+        let summary = forward_secrecy_summary_lines(&ctx).join("\n");
+        // The LOUD warning is present...
+        assert!(
+            summary.contains("WARNING: NO per-device forward secrecy"),
+            "Master-mode summary must warn that NO forward secrecy was gained: {summary}"
+        );
+        assert!(
+            summary.contains("UNCHANGED shared master key"),
+            "Master-mode summary must name the unchanged shared master key: {summary}"
+        );
+        assert!(
+            summary.contains("can STILL decrypt"),
+            "Master-mode summary must state a revoked holder STILL decrypts: {summary}"
+        );
+        assert!(
+            summary.contains("wrap_mode=PerDevice"),
+            "Master-mode summary must point at PerDevice as the fix: {summary}"
+        );
+        // ...and the PerDevice reassurance is ABSENT.
+        assert!(
+            !summary.contains("can no longer decrypt the re-keyed content"),
+            "Master-mode summary must NOT print the PerDevice forward-secrecy reassurance: \
+             {summary}"
+        );
+    }
+
+    /// Dual wrap (master wrap retained alongside per-device wraps) is ALSO not
+    /// forward-secret: the master wrap is an unchanged shared-secret path back to
+    /// the FileKey. It must get the same warning as Master.
+    #[test]
+    fn dual_wrap_rotation_warns_no_forward_secrecy() {
+        let master = master_key(0x42);
+        let keep = test_device("device-keep");
+        let ctx = dual_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+
+        assert!(
+            !rotation_grants_forward_secrecy(&ctx),
+            "Dual wrap retains the master wrap and must NOT be reported as forward-secret"
+        );
+        let summary = forward_secrecy_summary_lines(&ctx).join("\n");
+        assert!(
+            summary.contains("WARNING: NO per-device forward secrecy"),
+            "Dual-mode summary must warn that NO forward secrecy was gained: {summary}"
+        );
+        assert!(
+            !summary.contains("can no longer decrypt the re-keyed content"),
+            "Dual-mode summary must NOT print the PerDevice reassurance: {summary}"
+        );
+    }
+
+    /// The ONLY path that earns the reassurance: PerDevice with a real recipient
+    /// set (per-device-only wraps, no master wrap, manifest v3).
+    #[test]
+    fn per_device_wrap_rotation_reports_forward_secrecy() {
+        let master = master_key(0x42);
+        let keep = test_device("device-keep");
+        let ctx = per_device_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+
+        assert!(
+            rotation_grants_forward_secrecy(&ctx),
+            "PerDevice wrap with recipients MUST be reported as granting forward secrecy"
+        );
+        let summary = forward_secrecy_summary_lines(&ctx).join("\n");
+        assert!(
+            summary.contains("can no longer decrypt the re-keyed content"),
+            "PerDevice summary must print the forward-secrecy reassurance: {summary}"
+        );
+        assert!(
+            !summary.contains("WARNING: NO per-device forward secrecy"),
+            "PerDevice summary must NOT print the no-forward-secrecy warning: {summary}"
+        );
+    }
+
+    /// Defense in depth: PerDevice with an EMPTY recipient set is not a real
+    /// forward-secrecy guarantee (no one is a recipient); it must NOT earn the
+    /// reassurance. (In practice the write path rejects an empty PerDevice set,
+    /// but the messaging gate must not depend on that.)
+    #[test]
+    fn per_device_wrap_without_recipients_does_not_claim_forward_secrecy() {
+        let master = master_key(0x42);
+        let ctx = EncryptionContext::new(master.clone()).with_wrap_mode(
+            EngWrapMode::PerDevice,
+            Vec::new(),
+            None,
+        );
+        assert!(
+            !rotation_grants_forward_secrecy(&ctx),
+            "PerDevice with no recipients must NOT be reported as forward-secret"
+        );
+        let summary = forward_secrecy_summary_lines(&ctx).join("\n");
+        assert!(
+            summary.contains("WARNING: NO per-device forward secrecy"),
+            "empty-recipient PerDevice must warn rather than reassure: {summary}"
+        );
     }
 }

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -7380,6 +7380,7 @@ mod tests {
             written_at: 0,
             rel_path: Some(rel_path.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key: Some(base64::engine::general_purpose::STANDARD.encode(wrapped)),
             wrapped_file_keys: Vec::new(),
         }
@@ -8552,6 +8553,7 @@ enabled = false
             written_at: 0,
             rel_path: Some(rel_path.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key,
             wrapped_file_keys,
         };
@@ -8835,6 +8837,7 @@ enabled = false
             written_at: 0,
             rel_path: Some("plain.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -439,6 +439,14 @@ enum DeviceAction {
         /// Merge the local registry with the storage-backed fleet registry
         #[arg(long)]
         sync_remote: bool,
+        /// TIN-1417 B4 migration escape hatch: explicitly accept and re-sign an
+        /// UNSIGNED (legacy) remote registry during `--sync-remote`. Without this
+        /// flag an unsigned remote is REFUSED on the merge path, because merging
+        /// then re-signing it with the local master would launder an
+        /// attacker-injected recipient into a validly-signed registry. Only pass
+        /// this when you trust the remote object store has not been tampered with.
+        #[arg(long, requires = "sync_remote")]
+        accept_unsigned_remote: bool,
     },
     /// List enrolled devices
     List,
@@ -738,7 +746,17 @@ async fn main() -> Result<()> {
                 name,
                 repair_placeholder,
                 sync_remote,
-            } => cmd_device_enroll(&config, name, repair_placeholder, sync_remote).await,
+                accept_unsigned_remote,
+            } => {
+                cmd_device_enroll(
+                    &config,
+                    name,
+                    repair_placeholder,
+                    sync_remote,
+                    accept_unsigned_remote,
+                )
+                .await
+            }
             DeviceAction::List => cmd_device_list(),
             DeviceAction::Revoke { name } => cmd_device_revoke(&config, &name),
             DeviceAction::Status => cmd_device_status(),
@@ -4210,6 +4228,7 @@ async fn cmd_device_enroll(
     name: Option<String>,
     repair_placeholder: bool,
     sync_remote: bool,
+    accept_unsigned_remote: bool,
 ) -> Result<()> {
     let device_name = name.unwrap_or_else(tcfs_secrets::device::default_device_name);
     let registry_path = tcfs_secrets::device::default_registry_path();
@@ -4261,19 +4280,32 @@ async fn cmd_device_enroll(
     if sync_remote {
         let op = build_operator(config).await?;
         let meta_prefix = config.storage.resolved_prefix();
-        // TIN-1417 B4: verify the remote registry before merging so a tampered
-        // remote registry is rejected rather than silently merged into ours.
+        // TIN-1417 B4: verify the remote registry before merging. The remote object
+        // store is the primary tamper surface, so a signature-PRESENT-but-invalid
+        // remote is hard-rejected by `load_remote_verified`. An UNSIGNED (legacy)
+        // remote verifies as `UnsignedLegacy` and its trust MUST be bound here: if
+        // we merged it and then re-signed the result with our real master, an
+        // attacker who stripped the signature and injected a recipient would have
+        // their entry LAUNDERED into a validly-signed registry. So we refuse to
+        // merge an unsigned remote unless the operator explicitly opts in with
+        // `--accept-unsigned-remote` (loud warning below).
         let remote = match master_key_for_registry_signing(config) {
             Some(mk) => {
-                let (remote, _trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+                let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
                     &op,
                     meta_prefix,
                     mk.as_bytes(),
                 )
                 .await?;
+                enforce_remote_merge_trust(trust, accept_unsigned_remote)?;
                 remote
             }
-            None => tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?,
+            None => {
+                // No master key available: we cannot verify the remote at all, and
+                // we will write the merged result UNSIGNED anyway (no laundering
+                // into a signed registry is possible). Preserve legacy behaviour.
+                tcfs_secrets::device::DeviceRegistry::load_remote(&op, meta_prefix).await?
+            }
         };
         merge_device_registry(&mut registry, &remote)?;
         match master_key_for_registry_signing(config) {
@@ -4316,6 +4348,59 @@ async fn cmd_device_enroll(
     }
 
     Ok(())
+}
+
+/// TIN-1417 B4 — close the unsigned-remote LAUNDERING bypass on the enroll
+/// `--sync-remote` path.
+///
+/// `load_remote_verified` already HARD-REJECTS a signature-present-but-invalid
+/// remote (tampering). The remaining hole is `RegistryTrust::UnsignedLegacy`: an
+/// attacker can strip the signature off the remote `devices.json` and inject a
+/// hostile recipient; the stripped registry verifies as "unsigned" rather than
+/// "tampered". If we merged that into our local registry and then re-signed the
+/// result with the real master key, the injected recipient would be laundered
+/// into a validly-signed registry — defeating B4 entirely.
+///
+/// So we REFUSE to merge an unsigned remote by default. The operator may opt in
+/// with `--accept-unsigned-remote` (e.g. a genuine one-time migration of a
+/// trusted legacy fleet), which logs a loud warning and proceeds.
+///
+/// MIGRATION WINDOW (TODO TIN-1417 B5, hard-reject by 2026-09-01): once all
+/// fleets have re-signed at least once, drop `--accept-unsigned-remote` and make
+/// an unsigned remote on the merge path an unconditional hard error. Track the
+/// last-seen-unsigned timestamp in fleet telemetry to confirm the window can
+/// close.
+fn enforce_remote_merge_trust(
+    trust: tcfs_secrets::device::RegistryTrust,
+    accept_unsigned_remote: bool,
+) -> Result<()> {
+    match trust {
+        tcfs_secrets::device::RegistryTrust::Signed => Ok(()),
+        tcfs_secrets::device::RegistryTrust::UnsignedLegacy => {
+            if accept_unsigned_remote {
+                tracing::warn!(
+                    "TIN-1417 B4: merging an UNSIGNED (legacy) remote device registry because \
+                     --accept-unsigned-remote was passed. Its recipient set is UNVERIFIED; you \
+                     are about to RE-SIGN it with this device's master key. Only proceed if you \
+                     trust the remote object store has not been tampered with."
+                );
+                eprintln!(
+                    "WARNING: accepting and re-signing an UNSIGNED remote device registry \
+                     (--accept-unsigned-remote). Its recipients are UNVERIFIED."
+                );
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "TIN-1417 B4: refusing to merge an UNSIGNED (legacy) remote device registry \
+                     on the enroll --sync-remote path. Merging then re-signing it with this \
+                     device's master key would launder any attacker-injected recipient into a \
+                     validly-signed registry. Re-save the remote with a master-key-holding \
+                     command to sign it, or (only if you trust the remote store) re-run with \
+                     --accept-unsigned-remote to explicitly accept and re-sign it."
+                );
+            }
+        }
+    }
 }
 
 fn repair_placeholder_device_key(
@@ -6379,6 +6464,114 @@ mod tests {
         assert!(tcfs_secrets::device::is_real_age_public_key(
             &merged.public_key
         ));
+    }
+
+    // ── TIN-1417 B4: unsigned-remote LAUNDERING bypass is BLOCKED ──────────────
+
+    /// End-to-end attack reproduction: an attacker with object-store write access
+    /// strips the signature off the remote `devices.json` and injects a hostile
+    /// recipient. A normal master-holder running `tcfs device enroll --sync-remote`
+    /// must REFUSE to merge it (so the injected recipient is never re-signed into a
+    /// validly-signed registry), unless `--accept-unsigned-remote` is passed.
+    #[tokio::test]
+    async fn unsigned_remote_with_injected_recipient_is_refused_not_laundered() {
+        let op = memory_op();
+        let meta_prefix = "data";
+        let master = master_key(0x42);
+
+        // 1. Honest fleet publishes a SIGNED remote registry.
+        let mut honest = tcfs_secrets::device::DeviceRegistry::default();
+        honest.enroll(
+            "alpha",
+            &tcfs_secrets::device::generate_local_device_key().public_key,
+            None,
+        );
+        honest
+            .sync_to_remote_signed(&op, meta_prefix, master.as_bytes())
+            .await
+            .unwrap();
+
+        // 2. Attacker rewrites the remote: injects a hostile recipient AND strips
+        //    the signature envelope so it reads as UnsignedLegacy (not "tampered").
+        let key = format!("{meta_prefix}/tcfs-meta/devices.json");
+        let raw = op.read(&key).await.unwrap().to_bytes().to_vec();
+        let mut value: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        let attacker_pubkey = tcfs_secrets::device::generate_local_device_key().public_key;
+        value["devices"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "name": "attacker",
+                "device_id": "attacker-id",
+                "public_key": attacker_pubkey,
+                "enrolled_at": 1,
+                "revoked": false
+            }));
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("registry_signature");
+        obj.remove("signer_pubkey");
+        obj.remove("sig_alg");
+        op.write(&key, serde_json::to_vec(&value).unwrap())
+            .await
+            .unwrap();
+
+        // 3. Master-holder loads + verifies the remote: it is UnsignedLegacy
+        //    (signature stripped), NOT a hard tamper error.
+        let (remote, trust) = tcfs_secrets::device::DeviceRegistry::load_remote_verified(
+            &op,
+            meta_prefix,
+            master.as_bytes(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(trust, tcfs_secrets::device::RegistryTrust::UnsignedLegacy);
+        assert!(
+            remote.devices.iter().any(|d| d.name == "attacker"),
+            "sanity: the stripped remote really does carry the injected recipient"
+        );
+
+        // 4. The merge-path trust gate must REFUSE it (no laundering).
+        let err = enforce_remote_merge_trust(trust.clone(), false).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("UNSIGNED") && msg.contains("launder"),
+            "unsigned remote must be refused on the merge path: {msg}"
+        );
+
+        // 5. Prove the laundering would have happened WITHOUT the gate: if we had
+        //    merged + re-signed, the attacker's recipient would be in a validly
+        //    signed registry. The gate is what prevents that, so we never merge.
+        let mut local = tcfs_secrets::device::DeviceRegistry::default();
+        // Gate refuses -> local stays clean; we never call merge.
+        assert!(
+            !local.devices.iter().any(|d| d.name == "attacker"),
+            "local registry must NOT contain the laundered recipient"
+        );
+        // Demonstrate the counterfactual is real (defense-in-depth assertion):
+        merge_device_registry(&mut local, &remote).unwrap();
+        local.sign(master.as_bytes()).unwrap();
+        assert!(
+            local.find("attacker").is_some()
+                && local.verify_signature(master.as_bytes()).unwrap()
+                    == tcfs_secrets::device::RegistryTrust::Signed,
+            "counterfactual: merging an unsigned remote then re-signing DOES launder \
+             the recipient — which is exactly why the merge-path gate must refuse it"
+        );
+    }
+
+    /// The explicit operator escape hatch (`--accept-unsigned-remote`) allows the
+    /// unsigned remote through, for genuine one-time legacy migration.
+    #[test]
+    fn accept_unsigned_remote_flag_allows_merge() {
+        enforce_remote_merge_trust(tcfs_secrets::device::RegistryTrust::UnsignedLegacy, true)
+            .expect("--accept-unsigned-remote must allow an unsigned remote through");
+    }
+
+    /// A signed remote always passes the gate regardless of the flag.
+    #[test]
+    fn signed_remote_passes_merge_gate() {
+        enforce_remote_merge_trust(tcfs_secrets::device::RegistryTrust::Signed, false)
+            .expect("a signed remote must pass the merge gate");
     }
 
     #[test]

--- a/crates/tcfs-cli/src/main.rs
+++ b/crates/tcfs-cli/src/main.rs
@@ -268,6 +268,19 @@ enum Commands {
         non_interactive: bool,
     },
 
+    /// Scoped, per-device-aware FileKey rotation (TIN-1899 / B2 forward secrecy)
+    ///
+    /// SEPARATE from `rotate-key` (which rotates the shared MASTER key and only
+    /// re-wraps master-wrapped manifests). `key rotate <prefix>` generates a
+    /// FRESH FileKey for every manifest under <prefix>, re-encrypts the content
+    /// under new BLAKE3 content addresses, and re-wraps to the CURRENT
+    /// (post-revocation) recipient set — so a revoked device that is absent from
+    /// the recipient set can no longer decrypt the re-keyed content.
+    Key {
+        #[command(subcommand)]
+        action: KeyAction,
+    },
+
     /// Reconcile local directory with remote storage
     ///
     /// Diffs local tree against remote index and shows what would change.
@@ -465,6 +478,33 @@ enum DeviceAction {
         /// Render QR code in terminal (compact encoding for phone scanning)
         #[arg(long)]
         qr: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum KeyAction {
+    /// Rotate FileKeys for all manifests under a prefix (forward secrecy).
+    ///
+    /// Without `--rotate-keys` this is a dry-run that reports the projected
+    /// bytes-to-rewrite. With `--rotate-keys` it generates fresh FileKeys,
+    /// re-encrypts content under new BLAKE3 addresses, re-wraps to the current
+    /// recipient set, publishes new manifests, and GCs the orphaned old chunks.
+    Rotate {
+        /// Remote prefix under which to rotate (e.g. `projects/secret`). Relative
+        /// to the configured storage prefix; manifests are scanned under
+        /// `<storage_prefix>/manifests/<prefix>`.
+        prefix: String,
+        /// Actually perform the rotation. Without this flag the command only
+        /// projects the bytes-to-rewrite and exits (safe dry-run).
+        #[arg(long)]
+        rotate_keys: bool,
+        /// Resume an interrupted rotation from its `.rotate-state.json`.
+        #[arg(long)]
+        resume: bool,
+        /// Skip the interactive confirmation prompt (for automation). Has no
+        /// effect without `--rotate-keys`.
+        #[arg(long)]
+        non_interactive: bool,
     },
 }
 
@@ -800,6 +840,14 @@ async fn main() -> Result<()> {
             password,
             non_interactive,
         } => cmd_rotate_key(&config, old_key_file.as_deref(), password, non_interactive).await,
+        Commands::Key { action } => match action {
+            KeyAction::Rotate {
+                prefix,
+                rotate_keys,
+                resume,
+                non_interactive,
+            } => cmd_key_rotate(&config, &prefix, rotate_keys, resume, non_interactive).await,
+        },
         Commands::Reconcile {
             path,
             prefix,
@@ -4209,13 +4257,38 @@ fn cmd_device_revoke(config: &tcfs_core::config::TcfsConfig, name: &str) -> Resu
     let registry_path = tcfs_secrets::device::default_registry_path();
     let mut registry = tcfs_secrets::device::DeviceRegistry::load(&registry_path)?;
 
+    // Capture the public key for the forward-secrecy notice before mutating.
+    let recipient = registry.find(name).map(|d| d.public_key.clone());
+
     if registry.revoke(name) {
-        // TIN-1417 B4: re-sign so the revocation is recorded in a signed envelope
-        // (revoked + revoked_at), making per-device revocation trustworthy.
+        // TIN-1899: recipient-set REMOVAL is the DEFAULT, cheap, immediate action.
+        // `revoke()` drops the device from `active_devices()`, so every recipient
+        // set built afterwards (CLI/daemon/FileProvider via load_verified) excludes
+        // it: NO new content is wrapped to the revoked device. We re-sign so the
+        // signed envelope records `revoked + revoked_at` and the removal is
+        // trustworthy (TIN-1417 B4).
         save_registry_signed_or_warn(&mut registry, &registry_path, config)?;
-        println!("Revoked device: {}", name);
+        println!("Revoked device: {name}");
+        println!("  Dropped from the recipient set (immediate): no NEW content will be wrapped to this device.");
+        if let Some(recipient) = recipient {
+            println!("  Removed age recipient: {recipient}");
+        }
+
+        // LOUD forward-secrecy warning: recipient-set removal alone does NOT
+        // re-key content the device could already read.
+        eprintln!();
+        eprintln!(
+            "  WARNING (forward secrecy): the revoked device RETAINS read access to content it \
+             already pulled AND to any content that has not yet been re-keyed (its old FileKey \
+             wraps and cached chunks are unchanged)."
+        );
+        eprintln!(
+            "  To achieve forward secrecy, re-key the affected content (expensive):\n      \
+             tcfs key rotate <prefix> --rotate-keys\n  This generates fresh FileKeys, re-encrypts \
+             content under new addresses, and re-wraps ONLY to the current recipient set."
+        );
     } else {
-        anyhow::bail!("Device '{}' not found", name);
+        anyhow::bail!("Device '{name}' not found");
     }
 
     Ok(())
@@ -4992,7 +5065,20 @@ struct KeyRotationState {
     status: KeyRotationStatus,
     rotated_manifests: u64,
     already_rotated_manifests: u64,
-    skipped_plaintext_manifests: u64,
+    /// Manifests that carry NO wrapped FileKey at all (genuinely plaintext /
+    /// unencrypted content). The master rotate has nothing to re-wrap for these,
+    /// so they are skipped. Renamed from the old `skipped_plaintext_manifests`
+    /// (TIN-1899): that name conflated two very different cases. This counter now
+    /// means *only* "no key material present". Per-device-only manifests are
+    /// tracked separately by `skipped_per_device_manifests`.
+    skipped_keyless_manifests: u64,
+    /// Manifests that carry ONLY per-device wraps (`encrypted_file_key == None`,
+    /// `wrapped_file_keys` non-empty) and therefore cannot be re-wrapped by the
+    /// MASTER rotate (TIN-1899). The scoped `tcfs key rotate <prefix>` command is
+    /// the only path that re-keys these; the master rotate records them here and
+    /// loudly tells the operator to run the scoped command for forward secrecy.
+    #[serde(default)]
+    skipped_per_device_manifests: u64,
     error_count: u64,
     last_manifest_path: Option<String>,
 }
@@ -5007,7 +5093,8 @@ impl KeyRotationState {
             status: KeyRotationStatus::RewritingManifests,
             rotated_manifests: 0,
             already_rotated_manifests: 0,
-            skipped_plaintext_manifests: 0,
+            skipped_keyless_manifests: 0,
+            skipped_per_device_manifests: 0,
             error_count: 0,
             last_manifest_path: None,
         }
@@ -5017,7 +5104,8 @@ impl KeyRotationState {
         self.status = KeyRotationStatus::RewritingManifests;
         self.rotated_manifests = 0;
         self.already_rotated_manifests = 0;
-        self.skipped_plaintext_manifests = 0;
+        self.skipped_keyless_manifests = 0;
+        self.skipped_per_device_manifests = 0;
         self.error_count = 0;
         self.last_manifest_path = None;
     }
@@ -5304,7 +5392,17 @@ async fn rotate_manifests_with_resume(
         let wrapped_b64 = match &manifest.encrypted_file_key {
             Some(k) => k.clone(),
             None => {
-                state.skipped_plaintext_manifests += 1;
+                // TIN-1899: distinguish genuinely-keyless (plaintext) manifests
+                // from per-device-only (v3) manifests. The MASTER rotate cannot
+                // re-wrap per-device manifests (no master wrap to read) and must
+                // NOT silently treat them as plaintext — that was the old
+                // forward-secrecy gap. Count them separately and tell the
+                // operator to run the scoped `tcfs key rotate <prefix>`.
+                if manifest.wrapped_file_keys.is_empty() {
+                    state.skipped_keyless_manifests += 1;
+                } else {
+                    state.skipped_per_device_manifests += 1;
+                }
                 state.last_manifest_path = Some(path.clone());
                 write_rotation_state(state_path, state)?;
                 continue;
@@ -5468,10 +5566,25 @@ async fn cmd_rotate_key(
         rotation.state.already_rotated_manifests
     );
     println!(
-        "  Manifests skipped (plaintext): {}",
-        rotation.state.skipped_plaintext_manifests
+        "  Manifests skipped (keyless/plaintext): {}",
+        rotation.state.skipped_keyless_manifests
+    );
+    println!(
+        "  Manifests skipped (per-device only): {}",
+        rotation.state.skipped_per_device_manifests
     );
     println!("  New master key: {}", key_path.display());
+
+    if rotation.state.skipped_per_device_manifests > 0 {
+        eprintln!();
+        eprintln!(
+            "  WARNING: {} per-device-only (v3) manifest(s) were NOT re-keyed by this MASTER \
+             rotation.\n  The master rotate cannot re-wrap content that carries no master wrap. \
+             To rotate FileKeys for per-device content (forward secrecy on device revoke), run:\n    \
+             tcfs key rotate <prefix> --rotate-keys",
+            rotation.state.skipped_per_device_manifests
+        );
+    }
 
     #[cfg(unix)]
     if let Ok(mut client) = connect_daemon(&config.daemon.socket).await {
@@ -5483,6 +5596,571 @@ async fn cmd_rotate_key(
             .await;
         println!("  Daemon notified with new key.");
     }
+
+    Ok(())
+}
+
+// ── `tcfs key rotate <prefix>` (TIN-1899 / B2 forward secrecy) ─────────────
+//
+// Scoped, per-device-aware FileKey rotation. SEPARATE from the master
+// `rotate-key` above (which re-wraps master-wrapped manifests under a new master
+// key). This command:
+//   1. Decrypts each manifest's current FileKey via the existing read path
+//      (master OR per-device, per the manifest's wrap shape).
+//   2. Generates a FRESH random FileKey; re-encrypts every chunk under it and
+//      uploads the new ciphertext under its NEW BLAKE3 content address.
+//   3. Re-wraps the new FileKey to the CURRENT (post-revocation) recipient set
+//      resolved from the VERIFIED device registry, honoring `crypto.wrap_mode`.
+//      A device absent from that set gets NO wrap -> cannot decrypt the re-key.
+//   4. Publishes the new manifest, then GCs orphaned old chunks once no live
+//      manifest references them (reference-safe; never deletes referenced data).
+//
+// Resumable via `.rotate-state.json`: a kill mid-run resumes, skipping manifests
+// already published.
+
+/// Resumable state for the scoped per-device key rotation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct ScopedRotationState {
+    version: u32,
+    started_at: u64,
+    /// Full manifest prefix scanned (resolved storage prefix + scope).
+    manifest_prefix: String,
+    /// Manifest object keys that have been fully re-keyed AND published.
+    /// Re-reading these on resume is a no-op (idempotent skip).
+    done_manifests: Vec<String>,
+    /// Count of manifests re-keyed this run (cumulative across resumes).
+    rotated_manifests: u64,
+    /// Manifests skipped because they carry NO FileKey at all (plaintext).
+    skipped_keyless_manifests: u64,
+    /// Manifests skipped on resume because they were already published.
+    already_done_manifests: u64,
+    /// Total plaintext bytes re-encrypted (for reporting).
+    bytes_rewritten: u64,
+    /// Set once every in-scope manifest has been published; gates GC.
+    all_published: bool,
+}
+
+impl ScopedRotationState {
+    fn new(manifest_prefix: &str) -> Self {
+        Self {
+            version: 1,
+            started_at: now_epoch(),
+            manifest_prefix: manifest_prefix.to_string(),
+            done_manifests: Vec::new(),
+            rotated_manifests: 0,
+            skipped_keyless_manifests: 0,
+            already_done_manifests: 0,
+            bytes_rewritten: 0,
+            all_published: false,
+        }
+    }
+
+    fn is_done(&self, path: &str) -> bool {
+        self.done_manifests.iter().any(|p| p == path)
+    }
+
+    fn mark_done(&mut self, path: &str) {
+        if !self.is_done(path) {
+            self.done_manifests.push(path.to_string());
+        }
+    }
+}
+
+/// Resolve the scoped rotation's state-file path (adjacent to the sync state).
+fn scoped_rotation_state_path(config: &tcfs_core::config::TcfsConfig, scope: &str) -> PathBuf {
+    let base = resolve_state_path(config, None);
+    let parent = base.parent().unwrap_or(Path::new(".")).to_path_buf();
+    // Encode the scope so distinct prefixes get distinct resume files.
+    let tag: String = scope
+        .trim_matches('/')
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    parent.join(format!(".key-rotate-{tag}.rotate-state.json"))
+}
+
+fn write_scoped_rotation_state(path: &Path, state: &ScopedRotationState) -> Result<()> {
+    let data = serde_json::to_vec_pretty(state).context("serializing scoped rotation state")?;
+    atomic_write_bytes(path, &data, Some(0o600))
+}
+
+fn read_scoped_rotation_state(path: &Path) -> Result<ScopedRotationState> {
+    let data = std::fs::read(path)
+        .with_context(|| format!("reading scoped rotation state: {}", path.display()))?;
+    serde_json::from_slice(&data).context("parsing scoped rotation state")
+}
+
+/// Load the master key (required to verify the signed registry and to read/write
+/// master-wrapped manifests). Mirrors how the other CLI crypto paths resolve it.
+fn load_master_key_for_rotation(
+    config: &tcfs_core::config::TcfsConfig,
+) -> Result<tcfs_crypto::MasterKey> {
+    let key_path = config.crypto.master_key_file.clone().ok_or_else(|| {
+        anyhow::anyhow!(
+            "no master key configured (crypto.master_key_file); key rotation requires it to \
+             verify the signed device registry and read existing wraps"
+        )
+    })?;
+    read_master_key(&key_path)
+        .with_context(|| format!("reading master key: {}", key_path.display()))
+}
+
+/// Build the current (post-revocation) recipient set + this device's unwrap
+/// identity, honoring `crypto.wrap_mode`. Returns the `EncryptionContext` used
+/// for BOTH the read (unwrap) and write (re-wrap) sides of the rotation.
+fn rotation_encryption_context(
+    config: &tcfs_core::config::TcfsConfig,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    let device_id = load_device_id(config);
+    // Reuse the canonical builder: it loads the VERIFIED registry (post-B4
+    // load_verified), filters to active+real recipients, and applies the
+    // roll-call gate. A revoked device is dropped from active_devices() and thus
+    // from the recipient set -- exactly the forward-secrecy requirement.
+    build_encryption_context(config, &device_id, master_key)
+}
+
+/// Unwrap the FileKey carried by a manifest using the rotation context.
+///
+/// Mirrors the engine read path: prefer the per-device wrap (using this device's
+/// age identity), fall back to the master wrap when one is present (Dual/v2).
+/// Returns `Ok(None)` for a genuinely keyless (plaintext) manifest.
+fn unwrap_manifest_file_key(
+    manifest: &tcfs_sync::manifest::SyncManifest,
+    ctx: &tcfs_sync::engine::EncryptionContext,
+    manifest_path: &str,
+) -> Result<Option<tcfs_crypto::FileKey>> {
+    if !manifest.wrapped_file_keys.is_empty() {
+        let per_device: Result<tcfs_crypto::FileKey> = (|| {
+            let identity = ctx.device_identity.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "manifest {manifest_path} is per-device encrypted but this device has no age \
+                     identity to unwrap it (configure wrap_mode + device secret)"
+                )
+            })?;
+            let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
+                .wrapped_file_keys
+                .iter()
+                .map(|w| tcfs_crypto::AgeWrappedFileKey {
+                    recipient_device_id: w.recipient_device_id.clone(),
+                    recipient: w.recipient.clone(),
+                    algorithm: w.algorithm.clone(),
+                    wrapped_key: w.wrapped_key.clone(),
+                })
+                .collect();
+            tcfs_crypto::unwrap_file_key_with_age_identity(
+                &age_wraps,
+                &identity.secret,
+                Some(&identity.device_id),
+            )
+            .with_context(|| format!("unwrapping per-device file key for {manifest_path}"))
+        })();
+
+        match per_device {
+            Ok(fk) => return Ok(Some(fk)),
+            Err(per_device_err) => {
+                if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+                    let wrapped = base64::engine::general_purpose::STANDARD
+                        .decode(wrapped_b64)
+                        .context("decoding master-wrapped file key")?;
+                    return Ok(Some(
+                        tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped).with_context(|| {
+                            format!("unwrapping master file key for {manifest_path}")
+                        })?,
+                    ));
+                }
+                return Err(per_device_err);
+            }
+        }
+    }
+
+    if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+        let wrapped = base64::engine::general_purpose::STANDARD
+            .decode(wrapped_b64)
+            .context("decoding master-wrapped file key")?;
+        return Ok(Some(
+            tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
+                .with_context(|| format!("unwrapping master file key for {manifest_path}"))?,
+        ));
+    }
+
+    Ok(None)
+}
+
+/// Build the master wrap + per-device wraps for a fresh FileKey, honoring the
+/// context's `wrap_mode`. Returns `(encrypted_file_key, wrapped_file_keys,
+/// manifest_version)` mirroring the engine write path exactly.
+fn wrap_rotated_file_key(
+    ctx: &tcfs_sync::engine::EncryptionContext,
+    file_key: &tcfs_crypto::FileKey,
+) -> Result<(
+    Option<String>,
+    Vec<tcfs_sync::manifest::WrappedFileKey>,
+    u32,
+)> {
+    use tcfs_sync::engine::WrapMode;
+
+    let master_wrap = || -> Result<String> {
+        let wrapped = tcfs_crypto::wrap_key(&ctx.master_key, file_key)?;
+        Ok(base64::engine::general_purpose::STANDARD.encode(&wrapped))
+    };
+    let device_wraps = || -> Result<Vec<tcfs_sync::manifest::WrappedFileKey>> {
+        let wraps =
+            tcfs_crypto::wrap_file_key_for_age_recipients(file_key, &ctx.device_recipients)?;
+        Ok(wraps
+            .into_iter()
+            .map(|w| tcfs_sync::manifest::WrappedFileKey {
+                recipient_device_id: w.recipient_device_id,
+                recipient: w.recipient,
+                algorithm: w.algorithm,
+                wrapped_key: w.wrapped_key,
+            })
+            .collect())
+    };
+
+    match ctx.wrap_mode {
+        WrapMode::Master => Ok((Some(master_wrap()?), Vec::new(), 2)),
+        WrapMode::Dual => {
+            if ctx.device_recipients.is_empty() {
+                anyhow::bail!(
+                    "wrap_mode=Dual requires per-device recipients but none are configured"
+                );
+            }
+            Ok((Some(master_wrap()?), device_wraps()?, 2))
+        }
+        WrapMode::PerDevice => {
+            if ctx.device_recipients.is_empty() {
+                anyhow::bail!(
+                    "wrap_mode=PerDevice requires per-device recipients but none are configured"
+                );
+            }
+            // v3: per-device-only, NO master wrap -> a revoked device absent from
+            // the recipient set has no path to the FileKey.
+            Ok((None, device_wraps()?, 3))
+        }
+    }
+}
+
+enum RekeyOutcome {
+    Rotated { bytes_rewritten: u64 },
+    Keyless,
+}
+
+/// Re-key ONE manifest: decrypt the old FileKey, generate a fresh one,
+/// re-encrypt every chunk under it (new BLAKE3 addresses), re-wrap to the
+/// current recipient set, and publish the new manifest. The OLD chunks are
+/// intentionally left in place -- they are swept by the post-publish GC once no
+/// live manifest references them.
+async fn rekey_one_manifest(
+    op: &opendal::Operator,
+    remote_prefix: &str,
+    manifest_path: &str,
+    ctx: &tcfs_sync::engine::EncryptionContext,
+) -> Result<RekeyOutcome> {
+    let data = op
+        .read(manifest_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("reading manifest {manifest_path}: {e}"))?
+        .to_bytes();
+    let mut manifest = tcfs_sync::manifest::SyncManifest::from_bytes(&data)
+        .with_context(|| format!("parsing manifest {manifest_path}"))?;
+
+    let Some(old_file_key) = unwrap_manifest_file_key(&manifest, ctx, manifest_path)? else {
+        return Ok(RekeyOutcome::Keyless);
+    };
+
+    // file_id (AAD) is BLAKE3 of the plaintext file_hash. Plaintext is unchanged
+    // by re-keying, so file_id and file_hash stay identical -- only the FileKey
+    // (and therefore the ciphertext + its content address) changes.
+    let file_id: [u8; 32] = {
+        let hash = tcfs_chunks::hash_from_hex(&manifest.file_hash)
+            .with_context(|| format!("parsing file_hash for {manifest_path}"))?;
+        *hash.as_bytes()
+    };
+
+    let new_file_key = tcfs_crypto::generate_file_key();
+    let mut new_chunk_hashes: Vec<String> = Vec::with_capacity(manifest.chunks.len());
+    let mut bytes_rewritten: u64 = 0;
+
+    for (i, old_hash) in manifest.chunks.iter().enumerate() {
+        let old_chunk_key = format!("{remote_prefix}/chunks/{old_hash}");
+        let ciphertext = op
+            .read(&old_chunk_key)
+            .await
+            .map_err(|e| anyhow::anyhow!("reading chunk {old_chunk_key}: {e}"))?
+            .to_vec();
+        let plaintext = tcfs_crypto::decrypt_chunk(&old_file_key, i as u64, &file_id, &ciphertext)
+            .with_context(|| format!("decrypting chunk {i} of {manifest_path}"))?;
+        bytes_rewritten += plaintext.len() as u64;
+
+        let new_ciphertext =
+            tcfs_crypto::encrypt_chunk(&new_file_key, i as u64, &file_id, &plaintext)
+                .with_context(|| format!("re-encrypting chunk {i} of {manifest_path}"))?;
+        let new_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&new_ciphertext));
+        let new_chunk_key = format!("{remote_prefix}/chunks/{new_hash}");
+
+        // Content-addressed: if the new ciphertext already exists (idempotent
+        // resume / dedupe), the write is a harmless overwrite of identical bytes.
+        op.write(&new_chunk_key, new_ciphertext)
+            .await
+            .map_err(|e| anyhow::anyhow!("writing re-encrypted chunk {new_chunk_key}: {e}"))?;
+        new_chunk_hashes.push(new_hash);
+    }
+
+    // Swap in the new content addresses + new wraps, then publish.
+    manifest.chunks = new_chunk_hashes;
+    let (encrypted_file_key, wrapped_file_keys, version) =
+        wrap_rotated_file_key(ctx, &new_file_key)?;
+    manifest.encrypted_file_key = encrypted_file_key;
+    manifest.wrapped_file_keys = wrapped_file_keys;
+    manifest.version = version;
+
+    let new_data = manifest
+        .to_bytes()
+        .with_context(|| format!("serializing rotated manifest {manifest_path}"))?;
+    op.write(manifest_path, new_data)
+        .await
+        .map_err(|e| anyhow::anyhow!("publishing rotated manifest {manifest_path}: {e}"))?;
+
+    Ok(RekeyOutcome::Rotated { bytes_rewritten })
+}
+
+/// List the in-scope manifest object keys (non-directory) under the prefix.
+async fn list_scoped_manifests(
+    op: &opendal::Operator,
+    manifest_prefix: &str,
+) -> Result<Vec<String>> {
+    let entries = op
+        .list_with(manifest_prefix)
+        .recursive(true)
+        .await
+        .with_context(|| format!("listing manifests under {manifest_prefix}"))?;
+    let mut paths: Vec<String> = entries
+        .into_iter()
+        .filter(|e| !e.metadata().is_dir() && !e.path().ends_with('/'))
+        .map(|e| e.path().to_string())
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
+
+async fn cmd_key_rotate(
+    config: &tcfs_core::config::TcfsConfig,
+    scope: &str,
+    rotate_keys: bool,
+    resume: bool,
+    non_interactive: bool,
+) -> Result<()> {
+    let storage_prefix = config.storage.resolved_prefix().to_string();
+    let scope_clean = scope.trim_matches('/');
+    let manifest_prefix = if scope_clean.is_empty() {
+        format!("{storage_prefix}/manifests/")
+    } else {
+        format!("{storage_prefix}/manifests/{scope_clean}/")
+    };
+    let remote_prefix = storage_prefix.clone();
+
+    let master_key = load_master_key_for_rotation(config)?;
+    let ctx = rotation_encryption_context(config, &master_key);
+
+    let op = build_operator(config).await?;
+
+    println!("Scanning manifests under: {manifest_prefix}");
+    let manifests = list_scoped_manifests(&op, &manifest_prefix).await?;
+    if manifests.is_empty() {
+        println!("No manifests found under that prefix. Nothing to rotate.");
+        return Ok(());
+    }
+
+    // Project bytes-to-rewrite by summing manifest file sizes (cheap; reads
+    // manifests only, not chunks).
+    let mut projected_bytes: u64 = 0;
+    let mut encrypted_count: u64 = 0;
+    for path in &manifests {
+        if let Ok(data) = op.read(path).await {
+            if let Ok(m) = tcfs_sync::manifest::SyncManifest::from_bytes(&data.to_bytes()) {
+                let has_key = m.encrypted_file_key.is_some() || !m.wrapped_file_keys.is_empty();
+                if has_key {
+                    projected_bytes += m.file_size;
+                    encrypted_count += 1;
+                }
+            }
+        }
+    }
+
+    println!(
+        "  Manifests in scope: {} ({} encrypted)",
+        manifests.len(),
+        encrypted_count
+    );
+    println!(
+        "  Recipient set (post-revocation): {} device(s), wrap_mode={:?}",
+        ctx.device_recipients.len(),
+        ctx.wrap_mode
+    );
+    for r in &ctx.device_recipients {
+        println!("    - {} ({})", r.device_id, r.recipient);
+    }
+    println!(
+        "  Projected bytes to re-encrypt: {} ({:.2} MiB)",
+        projected_bytes,
+        projected_bytes as f64 / (1024.0 * 1024.0)
+    );
+
+    if !rotate_keys {
+        println!();
+        println!(
+            "Dry run -- no changes made. Re-run with --rotate-keys to perform the rotation \
+             (re-chunk + re-encrypt + re-wrap + GC)."
+        );
+        return Ok(());
+    }
+
+    // Confirmation prompt before the expensive rewrite.
+    if !non_interactive {
+        println!();
+        println!(
+            "This will re-encrypt {projected_bytes} bytes across {encrypted_count} file(s), \
+             upload new chunks, publish new manifests, and GC the orphaned old chunks."
+        );
+        let confirm =
+            rpassword::prompt_password("Type 'ROTATE' to confirm scoped FileKey rotation: ")
+                .context("reading confirmation")?;
+        if confirm != "ROTATE" {
+            anyhow::bail!("key rotation cancelled");
+        }
+    }
+
+    let state_path = scoped_rotation_state_path(config, scope);
+    let mut state = if resume && state_path.exists() {
+        let existing = read_scoped_rotation_state(&state_path)?;
+        if existing.manifest_prefix != manifest_prefix {
+            anyhow::bail!(
+                "resume state targets {} but this invocation resolved to {}",
+                existing.manifest_prefix,
+                manifest_prefix
+            );
+        }
+        println!(
+            "Resuming scoped rotation: {} manifest(s) already published.",
+            existing.done_manifests.len()
+        );
+        existing
+    } else {
+        if state_path.exists() && !resume {
+            anyhow::bail!(
+                "a scoped rotation is already in progress for this prefix ({}). Pass --resume to \
+                 continue it, or remove the state file to start over.",
+                state_path.display()
+            );
+        }
+        let s = ScopedRotationState::new(&manifest_prefix);
+        write_scoped_rotation_state(&state_path, &s)?;
+        s
+    };
+
+    println!();
+    println!("Re-keying manifests...");
+    for path in &manifests {
+        if state.is_done(path) {
+            state.already_done_manifests += 1;
+            continue;
+        }
+        match rekey_one_manifest(&op, &remote_prefix, path, &ctx).await {
+            Ok(RekeyOutcome::Rotated { bytes_rewritten }) => {
+                state.rotated_manifests += 1;
+                state.bytes_rewritten += bytes_rewritten;
+                state.mark_done(path);
+                write_scoped_rotation_state(&state_path, &state)?;
+                println!("  re-keyed: {path}");
+            }
+            Ok(RekeyOutcome::Keyless) => {
+                state.skipped_keyless_manifests += 1;
+                state.mark_done(path);
+                write_scoped_rotation_state(&state_path, &state)?;
+                println!("  skipped (keyless/plaintext): {path}");
+            }
+            Err(e) => {
+                // Persist progress and surface a resumable error. Already-published
+                // manifests are in done_manifests; old chunks are NOT yet GC'd, so
+                // nothing referenced by a live manifest can be lost.
+                write_scoped_rotation_state(&state_path, &state)?;
+                println!(
+                    "\nScoped rotation paused with resumable state preserved:\n  Resume state: {}\n  \
+                     Re-run with --resume after fixing the failure.",
+                    state_path.display()
+                );
+                return Err(e).with_context(|| format!("re-keying manifest {path}"));
+            }
+        }
+    }
+
+    // All in-scope manifests are now published with NEW chunk addresses. The old
+    // chunks are orphaned (no live manifest references them) and safe to sweep.
+    state.all_published = true;
+    write_scoped_rotation_state(&state_path, &state)?;
+
+    println!();
+    println!(
+        "GC: sweeping chunks no longer referenced by ANY live manifest under {remote_prefix} ..."
+    );
+    let cleanup = tcfs_sync::reconcile::cleanup_orphaned_chunks(
+        &op,
+        &remote_prefix,
+        Duration::from_secs(0),
+        SystemTime::now(),
+    )
+    .await
+    .context("GC of orphaned chunks after rotation")?;
+
+    println!(
+        "  GC: {} orphaned, {} deleted, {} referenced (kept), {} errors",
+        cleanup.orphaned_chunks_found,
+        cleanup.deleted_chunks.len(),
+        cleanup.referenced_chunks,
+        cleanup.delete_errors.len()
+    );
+    for (hash, err) in &cleanup.delete_errors {
+        eprintln!("    GC error: {hash}: {err}");
+    }
+
+    // Rotation complete: drop the resume artifact.
+    if let Err(e) = std::fs::remove_file(&state_path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            eprintln!(
+                "  WARN: failed to remove resume state {}: {e}",
+                state_path.display()
+            );
+        }
+    }
+
+    println!();
+    println!("Scoped FileKey rotation complete:");
+    println!("  Manifests re-keyed:      {}", state.rotated_manifests);
+    println!(
+        "  Skipped (keyless):       {}",
+        state.skipped_keyless_manifests
+    );
+    println!(
+        "  Already done (resume):   {}",
+        state.already_done_manifests
+    );
+    println!("  Bytes re-encrypted:      {}", state.bytes_rewritten);
+    println!(
+        "  Old chunks GC'd:         {}",
+        cleanup.deleted_chunks.len()
+    );
+    println!();
+    println!(
+        "Forward secrecy: devices absent from the current recipient set can no longer decrypt the \
+         re-keyed content. (They may still hold content they previously pulled.)"
+    );
 
     Ok(())
 }
@@ -7693,5 +8371,426 @@ enabled = false
         assert!(prepared.is_none());
         assert!(!paths.state_path.exists());
         assert!(!paths.pending_key_path.exists());
+    }
+
+    // ── TIN-1899: scoped per-device key rotation tests ──────────────────────
+
+    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext, WrapMode as EngWrapMode};
+
+    /// A throwaway age X25519 device identity for tests.
+    struct TestDevice {
+        device_id: String,
+        recipient: String,
+        secret: String,
+    }
+
+    fn test_device(device_id: &str) -> TestDevice {
+        // Reuse the production age X25519 keypair generator (avoids a direct
+        // `age` dev-dependency in tcfs-cli).
+        let key = tcfs_secrets::device::generate_local_device_key();
+        TestDevice {
+            device_id: device_id.to_string(),
+            recipient: key.public_key.clone(),
+            secret: key.secret_key.expose_secret().to_string(),
+        }
+    }
+
+    fn recipient_of(d: &TestDevice) -> tcfs_crypto::AgeFileKeyRecipient {
+        tcfs_crypto::AgeFileKeyRecipient {
+            device_id: d.device_id.clone(),
+            recipient: d.recipient.clone(),
+        }
+    }
+
+    fn identity_of(d: &TestDevice) -> DeviceUnwrapIdentity {
+        DeviceUnwrapIdentity {
+            device_id: d.device_id.clone(),
+            secret: d.secret.clone(),
+        }
+    }
+
+    /// Build a per-device (v3) EncryptionContext: per-device-only wraps, this
+    /// device's unwrap identity, and the given recipient set.
+    fn per_device_ctx(
+        master: &tcfs_crypto::MasterKey,
+        recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+        identity: DeviceUnwrapIdentity,
+    ) -> EncryptionContext {
+        EncryptionContext::new(master.clone()).with_wrap_mode(
+            EngWrapMode::PerDevice,
+            recipients,
+            Some(identity),
+        )
+    }
+
+    /// Seed a real encrypted file (chunks + manifest) into the operator using the
+    /// given context's wrap shape. Returns the published manifest path.
+    async fn seed_encrypted_file(
+        op: &Operator,
+        remote_prefix: &str,
+        rel_path: &str,
+        plaintext: &[u8],
+        ctx: &EncryptionContext,
+    ) -> String {
+        let file_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(plaintext));
+        let file_id: [u8; 32] = *tcfs_chunks::hash_from_hex(&file_hash).unwrap().as_bytes();
+        let file_key = tcfs_crypto::generate_file_key();
+
+        // One chunk for test simplicity (the production path chunks via FastCDC;
+        // re-keying is per-chunk-index either way).
+        let ciphertext = tcfs_crypto::encrypt_chunk(&file_key, 0, &file_id, plaintext).unwrap();
+        let chunk_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&ciphertext));
+        op.write(&format!("{remote_prefix}/chunks/{chunk_hash}"), ciphertext)
+            .await
+            .unwrap();
+
+        let (encrypted_file_key, wrapped_file_keys, version) =
+            wrap_rotated_file_key(ctx, &file_key).unwrap();
+
+        let manifest = tcfs_sync::manifest::SyncManifest {
+            version,
+            file_hash,
+            file_size: plaintext.len() as u64,
+            chunks: vec![chunk_hash],
+            vclock: tcfs_sync::conflict::VectorClock::new(),
+            written_by: "seed-device".into(),
+            written_at: 0,
+            rel_path: Some(rel_path.to_string()),
+            mode: None,
+            encrypted_file_key,
+            wrapped_file_keys,
+        };
+        let manifest_path = format!("{remote_prefix}/manifests/{rel_path}");
+        op.write(&manifest_path, manifest.to_bytes().unwrap())
+            .await
+            .unwrap();
+        manifest_path
+    }
+
+    /// Decrypt a published manifest's content end-to-end with the given context.
+    async fn decrypt_published(
+        op: &Operator,
+        remote_prefix: &str,
+        manifest_path: &str,
+        ctx: &EncryptionContext,
+    ) -> Result<Vec<u8>> {
+        let data = op.read(manifest_path).await.unwrap().to_vec();
+        let manifest = tcfs_sync::manifest::SyncManifest::from_bytes(&data).unwrap();
+        let fk = unwrap_manifest_file_key(&manifest, ctx, manifest_path)?
+            .ok_or_else(|| anyhow::anyhow!("keyless manifest"))?;
+        let file_id: [u8; 32] = *tcfs_chunks::hash_from_hex(&manifest.file_hash)
+            .unwrap()
+            .as_bytes();
+        let mut out = Vec::new();
+        for (i, hash) in manifest.chunks.iter().enumerate() {
+            let ct = op
+                .read(&format!("{remote_prefix}/chunks/{hash}"))
+                .await
+                .unwrap()
+                .to_vec();
+            let pt = tcfs_crypto::decrypt_chunk(&fk, i as u64, &file_id, &ct)?;
+            out.extend_from_slice(&pt);
+        }
+        Ok(out)
+    }
+
+    async fn chunk_count(op: &Operator, remote_prefix: &str) -> usize {
+        op.list_with(&format!("{remote_prefix}/chunks/"))
+            .recursive(true)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|e| !e.metadata().is_dir() && !e.path().ends_with('/'))
+            .count()
+    }
+
+    /// (a) After revoke X + scoped rotate, device X (absent from the new
+    /// recipient set) gets a HARD unwrap error on the re-keyed manifest, while a
+    /// still-current device decrypts fine.
+    #[tokio::test]
+    async fn scoped_rotate_revokes_per_device_read() {
+        let op = memory_op();
+        let master = master_key(0x42);
+        let keep = test_device("device-keep");
+        let revoke = test_device("device-revoke");
+
+        // Before rotation: BOTH devices are recipients (per-device-only v3).
+        let writer_ctx = per_device_ctx(
+            &master,
+            vec![recipient_of(&keep), recipient_of(&revoke)],
+            identity_of(&keep),
+        );
+        let plaintext = b"top secret payload that must rotate";
+        let manifest_path =
+            seed_encrypted_file(&op, "data", "secret/a.txt", plaintext, &writer_ctx).await;
+
+        // Sanity: the revoked device CAN read pre-rotation content.
+        let revoke_reader = per_device_ctx(
+            &master,
+            vec![recipient_of(&keep), recipient_of(&revoke)],
+            identity_of(&revoke),
+        );
+        assert_eq!(
+            decrypt_published(&op, "data", &manifest_path, &revoke_reader)
+                .await
+                .unwrap(),
+            plaintext
+        );
+
+        // Post-revocation recipient set: ONLY the kept device.
+        let rotate_ctx = per_device_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+        let outcome = rekey_one_manifest(&op, "data", &manifest_path, &rotate_ctx)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, RekeyOutcome::Rotated { .. }));
+
+        // The kept device still decrypts the re-keyed manifest.
+        let keep_reader = per_device_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+        assert_eq!(
+            decrypt_published(&op, "data", &manifest_path, &keep_reader)
+                .await
+                .unwrap(),
+            plaintext
+        );
+
+        // The revoked device gets a HARD unwrap error on the re-keyed manifest.
+        let revoke_after =
+            per_device_ctx(&master, vec![recipient_of(&revoke)], identity_of(&revoke));
+        let err = decrypt_published(&op, "data", &manifest_path, &revoke_after)
+            .await
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("unwrap") || msg.contains("no decryptable") || msg.contains("file key"),
+            "expected a hard unwrap error for the revoked device, got: {msg}"
+        );
+
+        // The re-keyed manifest carries NO wrap addressed to the revoked device.
+        let data = op.read(&manifest_path).await.unwrap().to_vec();
+        let m = tcfs_sync::manifest::SyncManifest::from_bytes(&data).unwrap();
+        assert!(
+            !m.wrapped_file_keys
+                .iter()
+                .any(|w| w.recipient_device_id == "device-revoke"),
+            "re-keyed manifest must not wrap to the revoked device"
+        );
+        assert!(m
+            .wrapped_file_keys
+            .iter()
+            .any(|w| w.recipient_device_id == "device-keep"));
+    }
+
+    /// (c) Orphaned old chunks are GC'd ONLY after publish, and referenced chunks
+    /// are never deleted.
+    #[tokio::test]
+    async fn scoped_rotate_gcs_orphans_only_after_publish() {
+        let op = memory_op();
+        let master = master_key(0x42);
+        let keep = test_device("device-keep");
+
+        let ctx = per_device_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+        let manifest_path =
+            seed_encrypted_file(&op, "data", "secret/a.txt", b"payload one", &ctx).await;
+
+        // Capture the original chunk address.
+        let before = op.read(&manifest_path).await.unwrap().to_vec();
+        let old_hash = tcfs_sync::manifest::SyncManifest::from_bytes(&before)
+            .unwrap()
+            .chunks[0]
+            .clone();
+        assert_eq!(chunk_count(&op, "data").await, 1);
+
+        // Re-key: writes a NEW chunk; the OLD chunk is still present (orphan).
+        rekey_one_manifest(&op, "data", &manifest_path, &ctx)
+            .await
+            .unwrap();
+        let after = op.read(&manifest_path).await.unwrap().to_vec();
+        let new_hash = tcfs_sync::manifest::SyncManifest::from_bytes(&after)
+            .unwrap()
+            .chunks[0]
+            .clone();
+        assert_ne!(
+            old_hash, new_hash,
+            "re-key must produce a new content address"
+        );
+        assert_eq!(
+            chunk_count(&op, "data").await,
+            2,
+            "old chunk is NOT deleted before GC"
+        );
+        assert!(op.exists(&format!("data/chunks/{old_hash}")).await.unwrap());
+
+        // GC SAFETY (reference correctness): after publish, the OLD chunk is no
+        // longer referenced by ANY live manifest and is identified as orphaned,
+        // while the NEW (referenced) chunk is NEVER classified as orphaned.
+        //
+        // NOTE: the opendal Memory backend reports `last_modified: None`, so the
+        // grace-gated *deletion* path conservatively keeps timestamp-less chunks
+        // (verified in tcfs-sync's plan_orphaned_chunk_cleanup_respects_grace_period).
+        // We therefore assert the orphan-identification invariant the rotation
+        // depends on for safety, rather than physical deletion on this backend.
+        let report = tcfs_sync::reconcile::find_orphaned_chunks(&op, "data")
+            .await
+            .unwrap();
+        assert_eq!(
+            report.orphaned_chunks,
+            vec![old_hash.clone()],
+            "exactly the old chunk is orphaned after publish"
+        );
+        assert_eq!(report.referenced_chunks, 1, "the new chunk is referenced");
+        assert!(
+            !report.orphaned_chunks.contains(&new_hash),
+            "the referenced new chunk must NEVER be classified as orphaned"
+        );
+
+        // The cleanup call runs cleanly and never deletes a referenced chunk; on
+        // a timestamp-bearing backend it would also delete the orphan.
+        let cleanup = tcfs_sync::reconcile::cleanup_orphaned_chunks(
+            &op,
+            "data",
+            Duration::from_secs(0),
+            SystemTime::now(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cleanup.orphaned_chunks_found, 1,
+            "GC found exactly the old orphan"
+        );
+        assert!(
+            !cleanup.deleted_chunks.contains(&new_hash),
+            "GC must never delete the referenced new chunk"
+        );
+        assert!(
+            op.exists(&format!("data/chunks/{new_hash}")).await.unwrap(),
+            "the live (referenced) chunk survives GC"
+        );
+    }
+
+    /// (b) Resumability: a kill mid-run leaves published manifests in
+    /// done_manifests, and the resume skips them without losing data.
+    #[tokio::test]
+    async fn scoped_rotate_state_resumes_published_manifests() {
+        let op = memory_op();
+        let master = master_key(0x42);
+        let keep = test_device("device-keep");
+        let ctx = per_device_ctx(&master, vec![recipient_of(&keep)], identity_of(&keep));
+
+        let m_a = seed_encrypted_file(&op, "data", "secret/a.txt", b"alpha", &ctx).await;
+        let m_b = seed_encrypted_file(&op, "data", "secret/b.txt", b"bravo", &ctx).await;
+
+        // Simulate a kill after publishing only manifest A.
+        let mut state = ScopedRotationState::new("data/manifests/secret/");
+        rekey_one_manifest(&op, "data", &m_a, &ctx).await.unwrap();
+        state.mark_done(&m_a);
+        state.rotated_manifests += 1;
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join(".key-rotate.json");
+        write_scoped_rotation_state(&state_path, &state).unwrap();
+
+        // Resume: A is skipped (idempotent), B is freshly re-keyed.
+        let resumed = read_scoped_rotation_state(&state_path).unwrap();
+        assert!(resumed.is_done(&m_a));
+        assert!(!resumed.is_done(&m_b));
+
+        let manifests = list_scoped_manifests(&op, "data/manifests/secret/")
+            .await
+            .unwrap();
+        let mut state = resumed;
+        for path in &manifests {
+            if state.is_done(path) {
+                state.already_done_manifests += 1;
+                continue;
+            }
+            rekey_one_manifest(&op, "data", path, &ctx).await.unwrap();
+            state.mark_done(path);
+            state.rotated_manifests += 1;
+        }
+        assert_eq!(state.already_done_manifests, 1);
+        assert!(state.is_done(&m_b));
+
+        // Both manifests decrypt cleanly with the kept device after resume.
+        assert_eq!(
+            decrypt_published(&op, "data", &m_a, &ctx).await.unwrap(),
+            b"alpha"
+        );
+        assert_eq!(
+            decrypt_published(&op, "data", &m_b, &ctx).await.unwrap(),
+            b"bravo"
+        );
+    }
+
+    /// (d) The renamed master-rotate counter distinguishes genuinely-plaintext
+    /// manifests from per-device-only manifests.
+    #[tokio::test]
+    async fn master_rotate_counter_distinguishes_plaintext_from_per_device() {
+        let op = memory_op();
+        let old_master = master_key(0x11);
+        let new_master = master_key(0x22);
+        let device = test_device("device-keep");
+
+        // 1) genuinely keyless (plaintext) manifest.
+        let plaintext_manifest = tcfs_sync::manifest::SyncManifest {
+            version: 2,
+            file_hash: "hash-plain".into(),
+            file_size: 0,
+            chunks: vec![],
+            vclock: tcfs_sync::conflict::VectorClock::new(),
+            written_by: "t".into(),
+            written_at: 0,
+            rel_path: Some("plain.txt".into()),
+            mode: None,
+            encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
+        };
+        op.write(
+            "data/manifests/plain",
+            plaintext_manifest.to_bytes().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // 2) per-device-only (v3) manifest: no master wrap, has device wraps.
+        let pd_ctx = per_device_ctx(
+            &old_master,
+            vec![recipient_of(&device)],
+            identity_of(&device),
+        );
+        seed_encrypted_file(&op, "data", "perdev.txt", b"secret", &pd_ctx).await;
+
+        // 3) a normal master-wrapped manifest (gets rotated).
+        op.write(
+            "data/manifests/master",
+            make_encrypted_manifest(&old_master, "hash-m", "master.txt")
+                .to_bytes()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let mut state = KeyRotationState::new("data/manifests/", Path::new("/tmp/pending"));
+        let _dir = tempfile::tempdir().unwrap();
+        let state_path = _dir.path().join("rotate-state.json");
+        rotate_manifests_with_resume(
+            &op,
+            "data/manifests/",
+            &old_master,
+            &new_master,
+            &mut state,
+            &state_path,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            state.skipped_keyless_manifests, 1,
+            "exactly one genuinely-plaintext manifest"
+        );
+        assert_eq!(
+            state.skipped_per_device_manifests, 1,
+            "exactly one per-device-only manifest (NOT counted as plaintext)"
+        );
+        assert_eq!(state.rotated_manifests, 1, "the master-wrapped one rotated");
     }
 }

--- a/crates/tcfs-core/src/config.rs
+++ b/crates/tcfs-core/src/config.rs
@@ -307,8 +307,46 @@ pub struct FuseConfig {
     pub cache_max_mb: u64,
 }
 
-/// E2E encryption configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// File-key wrap mode (TIN-1417 migration).
+///
+/// Controls how a regular file's per-file key is wrapped in its manifest. This
+/// replaces the legacy boolean `per_device_wrapping`. The three states form an
+/// EXPAND / CONTRACT migration ladder:
+///
+/// - [`WrapMode::Master`] (DEFAULT): wrap ONLY under the shared master key
+///   (`encrypted_file_key`). Byte-identical to the legacy default
+///   (`per_device_wrapping = false`). Any master/old-binary reader can decrypt.
+/// - [`WrapMode::Dual`] (EXPAND / transitional): emit BOTH the master wrap
+///   (`encrypted_file_key`, for rollback + master/old-binary readers) AND the
+///   per-device wraps (`wrapped_file_keys`). Stays manifest **version 2** and is
+///   back-compatible by construction. Safe to roll the fleet through.
+/// - [`WrapMode::PerDevice`] (CONTRACT): emit ONLY the per-device wraps and DROP
+///   the master wrap — true revocation. Bumps the manifest to **version 3** so
+///   pre-per-device binaries fail CLOSED instead of misreading a
+///   v2-with-no-`encrypted_file_key` as keyless. The daemon refuses to write
+///   PerDevice until a roll-call probe confirms every active (non-revoked)
+///   device has a real age recipient; until then it falls back to `Dual` and
+///   warns loudly (never silently drops the master wrap).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WrapMode {
+    /// Master-only wrap. Legacy default; byte-identical to `per_device_wrapping = false`.
+    #[default]
+    Master,
+    /// Transitional dual wrap: master wrap + per-device wraps (manifest v2).
+    Dual,
+    /// Per-device-only wrap, drops the master wrap (manifest v3, true revocation).
+    PerDevice,
+}
+
+/// E2E encryption configuration.
+///
+/// `Deserialize` is hand-written (rather than derived) so that the legacy
+/// boolean `per_device_wrapping` key still parses for back-compat: `true` maps
+/// to [`WrapMode::Dual`] (keeps the master fallback — safe), `false`/absent maps
+/// to [`WrapMode::Master`]. A present `wrap_mode` key always wins. Going forward
+/// `wrap_mode` is canonical and the only key serialized.
+#[derive(Debug, Clone, Serialize)]
 #[serde(default)]
 pub struct CryptoConfig {
     /// Enable client-side encryption (default: false until key is set up)
@@ -329,12 +367,11 @@ pub struct CryptoConfig {
     /// Generated once per vault. If unset and passphrase_file is used, a random
     /// salt is generated and must be persisted by the caller.
     pub kdf_salt: Option<String>,
-    /// Wrap file keys per-device (age/X25519) for non-revoked devices instead of
-    /// under the shared master key (TIN-1417). When true, new manifests carry
-    /// `wrapped_file_keys` and omit `encrypted_file_key`, so a revoked device
-    /// cannot decrypt newly written content. Default false (legacy shared-master)
-    /// until a fleet has real per-device identities enrolled.
-    pub per_device_wrapping: bool,
+    /// File-key wrap mode (TIN-1417). Default [`WrapMode::Master`] (legacy
+    /// shared-master). See [`WrapMode`] for the EXPAND/CONTRACT semantics. A
+    /// legacy `per_device_wrapping = true` config deserializes to
+    /// [`WrapMode::Dual`]; `false`/absent to [`WrapMode::Master`].
+    pub wrap_mode: WrapMode,
 }
 
 impl Default for CryptoConfig {
@@ -348,8 +385,77 @@ impl Default for CryptoConfig {
             device_identity: None,
             passphrase_file: None,
             kdf_salt: None,
-            per_device_wrapping: false,
+            wrap_mode: WrapMode::Master,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for CryptoConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Shadow struct mirrors the serialized shape but additionally accepts the
+        // legacy `per_device_wrapping` boolean. `wrap_mode`, when present, wins.
+        #[derive(Deserialize)]
+        #[serde(default)]
+        struct CryptoConfigShadow {
+            enabled: bool,
+            argon2_mem_cost_kib: u32,
+            argon2_time_cost: u32,
+            argon2_parallelism: u32,
+            master_key_file: Option<PathBuf>,
+            device_identity: Option<PathBuf>,
+            passphrase_file: Option<PathBuf>,
+            kdf_salt: Option<String>,
+            /// Canonical key. `None` when absent so the legacy key can decide.
+            wrap_mode: Option<WrapMode>,
+            /// Legacy back-compat key (TIN-1417). `true` -> Dual, `false`/absent -> Master.
+            per_device_wrapping: Option<bool>,
+        }
+
+        impl Default for CryptoConfigShadow {
+            fn default() -> Self {
+                let base = CryptoConfig::default();
+                Self {
+                    enabled: base.enabled,
+                    argon2_mem_cost_kib: base.argon2_mem_cost_kib,
+                    argon2_time_cost: base.argon2_time_cost,
+                    argon2_parallelism: base.argon2_parallelism,
+                    master_key_file: base.master_key_file,
+                    device_identity: base.device_identity,
+                    passphrase_file: base.passphrase_file,
+                    kdf_salt: base.kdf_salt,
+                    wrap_mode: None,
+                    per_device_wrapping: None,
+                }
+            }
+        }
+
+        let shadow = CryptoConfigShadow::deserialize(deserializer)?;
+
+        // Precedence: an explicit `wrap_mode` wins. Otherwise map the legacy
+        // `per_device_wrapping` boolean (true -> Dual, keeps the master fallback;
+        // false/absent -> Master). Default is Master.
+        let wrap_mode = match shadow.wrap_mode {
+            Some(mode) => mode,
+            None => match shadow.per_device_wrapping {
+                Some(true) => WrapMode::Dual,
+                Some(false) | None => WrapMode::Master,
+            },
+        };
+
+        Ok(CryptoConfig {
+            enabled: shadow.enabled,
+            argon2_mem_cost_kib: shadow.argon2_mem_cost_kib,
+            argon2_time_cost: shadow.argon2_time_cost,
+            argon2_parallelism: shadow.argon2_parallelism,
+            master_key_file: shadow.master_key_file,
+            device_identity: shadow.device_identity,
+            passphrase_file: shadow.passphrase_file,
+            kdf_salt: shadow.kdf_salt,
+            wrap_mode,
+        })
     }
 }
 
@@ -631,5 +737,86 @@ require_session = false
     fn auth_defaults_when_omitted() {
         let config: TcfsConfig = toml::from_str("").unwrap();
         assert!(config.auth.require_session);
+    }
+
+    // ── TIN-1417: crypto.wrap_mode tri-state + legacy back-compat ──────────
+
+    #[test]
+    fn wrap_mode_defaults_to_master() {
+        let config: TcfsConfig = toml::from_str("").unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::Master,
+            "wrap_mode must default to Master (byte-identical to legacy default)"
+        );
+        // Empty [crypto] section must also default to Master.
+        let config: TcfsConfig = toml::from_str("[crypto]\n").unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_explicit_values_parse() {
+        for (s, expected) in [
+            ("master", WrapMode::Master),
+            ("dual", WrapMode::Dual),
+            ("per_device", WrapMode::PerDevice),
+        ] {
+            let toml_str = format!("[crypto]\nwrap_mode = \"{s}\"\n");
+            let config: TcfsConfig = toml::from_str(&toml_str).unwrap();
+            assert_eq!(config.crypto.wrap_mode, expected, "wrap_mode = {s}");
+        }
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_true_maps_to_dual() {
+        // true -> Dual keeps the master fallback (safe transitional mode).
+        let toml_str = "[crypto]\nper_device_wrapping = true\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::Dual,
+            "legacy per_device_wrapping = true must map to Dual (keeps master fallback)"
+        );
+    }
+
+    #[test]
+    fn legacy_per_device_wrapping_false_maps_to_master() {
+        let toml_str = "[crypto]\nper_device_wrapping = false\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn explicit_wrap_mode_wins_over_legacy_key() {
+        // When both keys are present, wrap_mode is canonical and wins.
+        let toml_str = "[crypto]\nwrap_mode = \"per_device\"\nper_device_wrapping = false\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.crypto.wrap_mode,
+            WrapMode::PerDevice,
+            "explicit wrap_mode must win over a conflicting legacy per_device_wrapping"
+        );
+
+        let toml_str = "[crypto]\nwrap_mode = \"master\"\nper_device_wrapping = true\n";
+        let config: TcfsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.crypto.wrap_mode, WrapMode::Master);
+    }
+
+    #[test]
+    fn wrap_mode_serializes_canonically() {
+        // Going forward only wrap_mode is emitted (snake_case); never the legacy key.
+        let config = CryptoConfig {
+            wrap_mode: WrapMode::PerDevice,
+            ..Default::default()
+        };
+        let toml_str = toml::to_string(&config).unwrap();
+        assert!(
+            toml_str.contains("wrap_mode = \"per_device\""),
+            "serialized config must emit canonical wrap_mode: {toml_str}"
+        );
+        assert!(
+            !toml_str.contains("per_device_wrapping"),
+            "serialized config must not emit the legacy key: {toml_str}"
+        );
     }
 }

--- a/crates/tcfs-file-provider/Cargo.toml
+++ b/crates/tcfs-file-provider/Cargo.toml
@@ -51,6 +51,9 @@ required-features = ["uniffi"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Used by device_ctx grpc-feature tests to expose generated age secrets when
+# constructing inlined-config JSON (TIN-1417 Keychain inlining read-side tests).
+secrecy = { workspace = true }
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -119,11 +119,25 @@ pub(crate) fn build_encryption_context(
         .map(std::path::PathBuf::from)
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
 
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: the recipient set must come from a signature-VERIFIED registry.
+    // Like the daemon/CLI, an unsigned or tampered registry falls back to the
+    // shared master wrap rather than wrapping to an unverified recipient.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
+                 per-device recipients from an unverified registry — using master wrap."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }
@@ -207,9 +221,16 @@ mod tests {
             description: None,
             enrolled_at: 0,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
-        registry.save(&registry_path).expect("save registry");
+        // TIN-1417 B4: build_encryption_context now requires a signature-verified
+        // registry, so sign with the same master key the tests use.
+        registry
+            .save_signed(&registry_path, master().as_bytes())
+            .expect("save signed registry");
 
         let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
         tcfs_secrets::device::save_device_secret_key(&secret_path, &key.secret_key, true)
@@ -310,9 +331,14 @@ mod tests {
             description: None,
             enrolled_at: 0,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
-        registry.save(&registry_path).unwrap();
+        registry
+            .save_signed(&registry_path, master().as_bytes())
+            .unwrap();
 
         let config = serde_json::json!({
             "wrap_mode": "per_device",

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -37,7 +37,7 @@
 /// `encrypted_file_key`, so those backends would fall through to "no file key"
 /// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
 /// explicit error instead.
-#[cfg(any(feature = "direct", feature = "grpc"))]
+#[cfg(any(feature = "direct", test))]
 pub(crate) fn ensure_master_decryptable(
     manifest: &tcfs_sync::manifest::SyncManifest,
 ) -> anyhow::Result<()> {
@@ -116,6 +116,7 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
 fn resolve_recipients(
     config: &serde_json::Value,
     requested: tcfs_core::config::WrapMode,
+    master_key: &tcfs_crypto::MasterKey,
 ) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
     // Inlined-first: the Keychain-provided config copy carries the active
     // recipients so the sandboxed FileProvider never reads devices.json. These
@@ -196,7 +197,7 @@ fn resolve_recipients(
                 "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing \
                  per-device recipients from an unverified registry — using master wrap."
             );
-            return base;
+            return None;
         }
         Err(e) => {
             tracing::warn!(
@@ -316,7 +317,7 @@ pub(crate) fn build_encryption_context(
         return base;
     }
 
-    let (recipients, all_capable) = match resolve_recipients(config, requested) {
+    let (recipients, all_capable) = match resolve_recipients(config, requested, master_key) {
         Some(v) => v,
         None => return base,
     };

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -32,21 +32,38 @@
 /// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
 /// be copied to disk as raw ciphertext (silent corruption).
 ///
-/// The `direct`/`uniffi` backends only implement master-key unwrapping. A
-/// per-device manifest carries `wrapped_file_keys` and OMITS the master-wrapped
-/// `encrypted_file_key`, so those backends would fall through to "no file key"
-/// and write encrypted chunk bytes verbatim. This guard turns that into a loud,
-/// explicit error instead.
+/// The `direct`/`uniffi` backends only implement master-key unwrapping (they
+/// carry no per-device age identity). The decision mirrors the engine read
+/// switch (TIN-1898, `tcfs-sync/src/engine.rs` ~:2395): a manifest's
+/// `wrapped_file_keys` being non-empty is NOT on its own a reason to fail —
+/// what matters is whether a usable master wrap is also present.
+///
+/// - **Dual (v2)** manifests carry BOTH `wrapped_file_keys` AND a master
+///   `encrypted_file_key`. A backend with no per-device identity can (and must)
+///   fall back to the master wrap — exactly as the engine does. This guard
+///   therefore PERMITS Dual manifests; the master-unwrap path below handles
+///   them via `encrypted_file_key`.
+/// - **PerDevice (v3)** manifests carry `wrapped_file_keys` and OMIT the
+///   master wrap (`encrypted_file_key == None`). A master-only backend cannot
+///   decrypt them, so it would fall through to "no file key" and write
+///   encrypted chunk bytes verbatim. For these we stay strictly fail-closed and
+///   turn the situation into a loud, explicit error instead of materializing raw
+///   ciphertext.
+///
+/// In short: reject iff `wrapped_file_keys` is non-empty AND there is no master
+/// wrap to fall back to. This keeps `wrap_mode=master` and Dual content readable
+/// on the legacy backends while never silently materializing PerDevice/v3
+/// ciphertext.
 #[cfg(any(feature = "direct", test))]
 pub(crate) fn ensure_master_decryptable(
     manifest: &tcfs_sync::manifest::SyncManifest,
 ) -> anyhow::Result<()> {
-    if !manifest.wrapped_file_keys.is_empty() {
+    if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
         anyhow::bail!(
-            "manifest is per-device encrypted (wrapped_file_keys present) but this \
-             FileProvider backend only supports master-key unwrapping; refusing to \
-             materialize raw ciphertext. Use the gRPC backend with a device identity \
-             configured to read per-device content."
+            "manifest is per-device encrypted (wrapped_file_keys present, no master \
+             wrap) but this FileProvider backend only supports master-key unwrapping; \
+             refusing to materialize raw ciphertext. Use the gRPC backend with a device \
+             identity configured to read per-device content."
         );
     }
     Ok(())
@@ -849,10 +866,12 @@ mod tests {
         );
     }
 
-    /// The fail-loud guard for the master-only backends rejects per-device
-    /// manifests instead of copying raw ciphertext.
+    /// The fail-loud guard for the master-only backends rejects PerDevice/v3
+    /// manifests (wrapped_file_keys present, NO master wrap) instead of copying
+    /// raw ciphertext — but PERMITS Dual/v2 manifests (both wraps present) and
+    /// plain master-only manifests, mirroring the engine read switch (TIN-1898).
     #[test]
-    fn ensure_master_decryptable_rejects_per_device_manifest() {
+    fn ensure_master_decryptable_rejects_per_device_but_allows_dual_and_master() {
         let base = || tcfs_sync::manifest::SyncManifest {
             version: 2,
             file_hash: String::new(),
@@ -867,17 +886,38 @@ mod tests {
             wrapped_file_keys: Vec::new(),
         };
 
-        let mut per_device = base();
-        per_device
-            .wrapped_file_keys
-            .push(tcfs_sync::manifest::WrappedFileKey {
-                recipient_device_id: "device-a".to_string(),
-                recipient: "age1example".to_string(),
-                algorithm: "age-x25519-v1".to_string(),
-                wrapped_key: "deadbeef".to_string(),
-            });
-        assert!(ensure_master_decryptable(&per_device).is_err());
+        let wrap = || tcfs_sync::manifest::WrappedFileKey {
+            recipient_device_id: "device-a".to_string(),
+            recipient: "age1example".to_string(),
+            algorithm: "age-x25519-v1".to_string(),
+            wrapped_key: "deadbeef".to_string(),
+        };
 
+        // PerDevice/v3: wrapped_file_keys present, encrypted_file_key absent ->
+        // no master wrap to fall back to -> MUST fail closed.
+        let mut per_device = base();
+        per_device.wrapped_file_keys.push(wrap());
+        assert!(
+            ensure_master_decryptable(&per_device).is_err(),
+            "PerDevice/v3 (no master wrap) must fail closed"
+        );
+
+        // Dual/v2: BOTH wraps present -> master fallback is available -> PERMIT
+        // (the master-unwrap path handles it). Mirrors engine.rs ~:2434.
+        let mut dual = base();
+        dual.wrapped_file_keys.push(wrap());
+        dual.encrypted_file_key = Some("bWFzdGVyd3JhcA==".to_string());
+        assert!(
+            ensure_master_decryptable(&dual).is_ok(),
+            "Dual/v2 (both wraps) must be permitted via the master wrap"
+        );
+
+        // Plain master-only manifest stays readable, unchanged.
+        let mut master_only = base();
+        master_only.encrypted_file_key = Some("bWFzdGVyd3JhcA==".to_string());
+        assert!(ensure_master_decryptable(&master_only).is_ok());
+
+        // Plaintext (no wraps at all) stays readable, unchanged.
         assert!(ensure_master_decryptable(&base()).is_ok());
     }
 }

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -17,13 +17,17 @@
 //! carry. See PR body for details.
 //!
 //! BEHAVIOR CONTRACT (must stay true):
-//! - When `per_device_wrapping` is absent/false in the config (the default),
+//! - When `wrap_mode` is absent or `master` in the config (the default),
 //!   `build_encryption_context` returns exactly `EncryptionContext::new(mk)` —
 //!   byte-identical to the prior master-only behavior. Master-only manifests
-//!   read unchanged.
+//!   read unchanged. (The legacy `per_device_wrapping` boolean is still accepted
+//!   as an alias: `true` -> `dual`, `false`/absent -> `master`.)
 //! - When a per-device manifest is encountered without an available device
 //!   identity, the engine read switch fails CLOSED (clear error); we never
 //!   silently master-fall-back, and we never copy raw ciphertext to disk.
+//! - The `PerDevice` (CONTRACT) mode is gated behind the same roll-call probe as
+//!   the daemon: it is downgraded to `Dual` unless every active device carries a
+//!   real age recipient.
 
 /// Fail CLOSED when a manifest that this backend cannot decrypt would otherwise
 /// be copied to disk as raw ciphertext (silent corruption).
@@ -48,16 +52,47 @@ pub(crate) fn ensure_master_decryptable(
     Ok(())
 }
 
+/// Resolve the requested `wrap_mode` from an FP init-config JSON blob (TIN-1417).
+///
+/// Canonical key is `wrap_mode` (`"master" | "dual" | "per_device"`). The legacy
+/// boolean `per_device_wrapping` is still accepted as an alias (`true` -> Dual,
+/// `false`/absent -> Master); a present `wrap_mode` wins. Mirrors the
+/// `CryptoConfig` deserialize back-compat rule.
+#[cfg(feature = "grpc")]
+fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if let Some(raw) = config.get("wrap_mode").and_then(serde_json::Value::as_str) {
+        return match raw {
+            "master" => WrapMode::Master,
+            "dual" => WrapMode::Dual,
+            "per_device" => WrapMode::PerDevice,
+            other => {
+                tracing::warn!("unknown wrap_mode {other:?} in FileProvider config; using master");
+                WrapMode::Master
+            }
+        };
+    }
+    match config
+        .get("per_device_wrapping")
+        .and_then(serde_json::Value::as_bool)
+    {
+        Some(true) => WrapMode::Dual,
+        Some(false) | None => WrapMode::Master,
+    }
+}
+
 /// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
 /// mirroring `tcfsd`'s `build_encryption_context`.
 ///
 /// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
-/// unless the config explicitly sets `per_device_wrapping: true`. In that case
-/// it loads the device registry + this device's age secret and attaches them
-/// via `.with_device_wrapping`, exactly like the daemon.
+/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
+/// `per_device_wrapping: true` alias). In that case it loads the device registry
+/// plus this device's age secret and attaches them, like the daemon, and applies
+/// the same roll-call gate (PerDevice downgrades to Dual unless every active
+/// device has a real age recipient).
 ///
 /// Like the daemon, this falls back to the master-only context (and logs why)
-/// only when per-device wrapping is enabled but the registry/recipients/secret
+/// only when per-device wrapping is requested but the registry/recipients/secret
 /// are unavailable — it never produces a context that this device cannot read
 /// back. The engine's read switch independently fails CLOSED if it then meets a
 /// per-device manifest with no identity attached.
@@ -67,16 +102,14 @@ pub(crate) fn build_encryption_context(
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
 
     // Default-off: byte-identical master-only behavior unless explicitly enabled.
-    if !config
-        .get("per_device_wrapping")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-    {
+    let requested = wrap_mode_from_config(config);
+    if requested == WrapMode::Master {
         return base;
     }
 
@@ -89,7 +122,9 @@ pub(crate) fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
@@ -104,7 +139,7 @@ pub(crate) fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
@@ -117,13 +152,33 @@ pub(crate) fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
 
-    base.with_device_wrapping(recipients, Some(identity))
+    // Roll-call gate: refuse PerDevice (drop master wrap) unless every active
+    // device is per-device-capable; otherwise degrade to Dual + warn.
+    let effective = if requested == WrapMode::PerDevice {
+        let roll_call = registry.roll_call();
+        if roll_call.all_capable() {
+            WrapMode::PerDevice
+        } else {
+            tracing::warn!(
+                active = roll_call.active,
+                capable = roll_call.capable,
+                blockers = ?roll_call.incapable_devices,
+                "wrap_mode=PerDevice REFUSED by roll-call gate; falling back to Dual \
+                 (keeping the master wrap)"
+            );
+            WrapMode::Dual
+        }
+    } else {
+        requested
+    };
+
+    base.with_wrap_mode(effective, recipients, Some(identity))
 }
 
 #[cfg(all(test, feature = "grpc"))]
@@ -179,27 +234,50 @@ mod tests {
         );
     }
 
-    /// Explicit per_device_wrapping=false also stays master-only.
+    /// Explicit wrap_mode=master also stays master-only.
     #[test]
     fn explicit_disabled_is_master_only() {
+        let config = serde_json::json!({ "wrap_mode": "master" });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(ctx.device_recipients.is_empty());
+        assert!(ctx.device_identity.is_none());
+        // Legacy alias: per_device_wrapping=false also stays master-only.
         let config = serde_json::json!({ "per_device_wrapping": false });
         let ctx = build_encryption_context(&config, "device-a", &master());
         assert!(ctx.device_recipients.is_empty());
         assert!(ctx.device_identity.is_none());
     }
 
-    /// When enabled with a real registry + local secret, the context carries this
-    /// device's unwrap identity and the active-device recipient set.
+    /// Legacy `per_device_wrapping = true` maps to Dual (keeps the master
+    /// fallback) and still attaches recipients + this device's identity.
+    #[test]
+    fn legacy_per_device_wrapping_true_attaches_dual_context() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "per_device_wrapping": true,
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::Dual);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// When wrap_mode=per_device with a real registry + local secret, the context
+    /// carries this device's unwrap identity and the active-device recipient set,
+    /// and (roll-call satisfied) stays in PerDevice.
     #[test]
     fn enabled_attaches_device_identity_and_recipients() {
         let tmp = tempfile::TempDir::new().unwrap();
         let _pub = provision_device(tmp.path(), "device-a");
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
 
         assert_eq!(
             ctx.device_recipients.len(),
@@ -237,7 +315,7 @@ mod tests {
         registry.save(&registry_path).unwrap();
 
         let config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": registry_path.to_str().unwrap(),
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
@@ -263,7 +341,7 @@ mod tests {
 
         // Build the write context from the same registry the FP read context uses.
         let enabled_config = serde_json::json!({
-            "per_device_wrapping": true,
+            "wrap_mode": "per_device",
             "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
         });
         let write_ctx = build_encryption_context(&enabled_config, "device-a", &master());

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -87,34 +87,58 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
 /// Under the macOS FileProvider sandbox the `.appex` cannot `fs`-read
 /// `~/.config/tcfs` (where the device registry lives); it receives its config
 /// from the shared Keychain instead. The Swift host therefore inlines the
-/// already-VERIFIED active recipients into the Keychain config copy under
-/// `device_recipients`, exactly mirroring how it inlines `master_key_base64`.
-/// When that key is present we trust it verbatim and never touch the filesystem;
-/// otherwise we fall back to loading `devices.json` (the non-sandboxed path used
-/// by the daemon/CLI and by tests).
+/// active recipients into the Keychain config copy under `device_recipients`,
+/// mirroring how it inlines `master_key_base64`. When that key is present we
+/// prefer it over the filesystem; otherwise we fall back to loading
+/// `devices.json` (the non-sandboxed path used by the daemon/CLI and by tests).
+///
+/// TRUST SCOPE (read this carefully — it is a security boundary):
+/// The inlined recipients are RE-VALIDATED here for age-key WELL-FORMEDNESS
+/// only — each `recipient` must parse as a real `age::x25519::Recipient` (via
+/// `is_real_age_public_key`) or it is dropped from the wrap set. We do NOT, and
+/// cannot, verify the AUTHENTICITY of the underlying registry: the registry the
+/// Swift host reads is not signature-verified, so a forged/tampered registry
+/// could still inline a well-formed-but-attacker-controlled recipient. Closing
+/// that gap is the job of the Ed25519-signed device registry (B4, separate and
+/// currently unmerged); it is explicitly OUT OF SCOPE for this inlining change,
+/// which only mirrors the existing (forgeable) trust posture into the sandbox.
 ///
 /// Returns `(recipients, all_capable)`. `all_capable` reflects whether every
-/// active device carries a real age recipient — for the inlined path it is
-/// supplied by the host under `device_recipients_all_capable` (the host runs the
-/// same roll-call against the verified registry); for the fs path it is derived
-/// from the loaded registry's `roll_call()`. It gates the PerDevice contract
-/// mode exactly as the daemon's roll-call gate does.
+/// active device carries a real age recipient. We RE-DERIVE it HERE on the Rust
+/// side from our own re-validated recipient set rather than trusting the host's
+/// `device_recipients_all_capable` boolean (the Swift `isRealAgePublicKey` is a
+/// prefix/length heuristic, so a host over-count must never be allowed to drop
+/// the master wrap and lock this device out — see the inlined branch below). For
+/// the fs path it is likewise derived from the loaded registry's `roll_call()`.
+/// It gates the PerDevice contract mode exactly as the daemon's roll-call gate
+/// does.
 #[cfg(feature = "grpc")]
 fn resolve_recipients(
     config: &serde_json::Value,
     requested: tcfs_core::config::WrapMode,
 ) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
-    // Inlined-first: the Keychain-provided config copy carries the verified
-    // active recipients so the sandboxed FileProvider never reads devices.json.
+    // Inlined-first: the Keychain-provided config copy carries the active
+    // recipients so the sandboxed FileProvider never reads devices.json. These
+    // are re-validated for age-key WELL-FORMEDNESS below; their registry
+    // AUTHENTICITY is NOT verified here (out of scope — pending B4 signed
+    // registry).
     if let Some(arr) = config
         .get("device_recipients")
         .and_then(serde_json::Value::as_array)
     {
+        // Count every inlined entry the host *claims* is active so we can detect
+        // a host over-count: any entry that fails our own age-recipient parse
+        // means "not all active devices are per-device-capable" -> all_capable
+        // MUST be false regardless of what the host asserted.
+        let inlined_total = arr.len();
         let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = arr
             .iter()
             .filter_map(|entry| {
                 let device_id = entry.get("device_id")?.as_str()?.to_string();
                 let recipient = entry.get("recipient")?.as_str()?.to_string();
+                // Re-validate WELL-FORMEDNESS only (real age::x25519::Recipient
+                // parse). A Swift false-positive cannot inject a malformed
+                // recipient into the wrap set.
                 if !tcfs_secrets::device::is_real_age_public_key(&recipient) {
                     return None;
                 }
@@ -131,12 +155,24 @@ fn resolve_recipients(
             );
             return None;
         }
-        // The host computes capability against the verified registry; default to
-        // false (no PerDevice drop) when the signal is absent.
-        let all_capable = config
-            .get("device_recipients_all_capable")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
+        // HARDENING (availability): RE-DERIVE all_capable in Rust from our own
+        // re-validated recipient set — do NOT trust the host-provided
+        // `device_recipients_all_capable` boolean. The Swift `isRealAgePublicKey`
+        // is only a prefix/length heuristic; if it over-counts (asserts a
+        // malformed key is real) and we trusted its boolean, Rust could enter
+        // PerDevice, drop the master wrap, and lock out a device that actually
+        // lacks a usable recipient. all_capable is true iff EVERY inlined entry
+        // the host listed as active also parsed as a real age recipient here.
+        let all_capable = recipients.len() == inlined_total;
+        if !all_capable {
+            tracing::warn!(
+                "wrap_mode={requested:?}: {} of {} inlined recipient(s) failed Rust age-key \
+                 re-validation; re-deriving all_capable=false (keeping master wrap) regardless \
+                 of host device_recipients_all_capable",
+                inlined_total - recipients.len(),
+                inlined_total
+            );
+        }
         return Some((recipients, all_capable));
     }
 
@@ -615,7 +651,7 @@ mod tests {
         assert_eq!(
             ctx.wrap_mode,
             tcfs_sync::engine::WrapMode::PerDevice,
-            "inlined all_capable=true should keep PerDevice"
+            "Rust-re-derived all_capable (1 of 1 well-formed) should keep PerDevice"
         );
         assert_eq!(
             ctx.device_recipients.len(),
@@ -634,11 +670,65 @@ mod tests {
         );
     }
 
-    /// The inlined `device_recipients_all_capable=false` signal trips the same
-    /// roll-call gate as the fs path: PerDevice downgrades to Dual (keeping the
-    /// master wrap) even though recipients + secret are present.
+    /// all_capable is RE-DERIVED in Rust, NOT trusted from the host boolean.
+    /// Here a single inlined recipient is malformed (would fail the real
+    /// `age::x25519::Recipient` parse) while a second is well-formed, and the
+    /// host asserts `device_recipients_all_capable=true` (a Swift over-count via
+    /// its prefix/length heuristic). Rust must drop the malformed recipient,
+    /// re-derive all_capable=FALSE (1 of 2 entries failed re-validation), and
+    /// therefore downgrade PerDevice -> Dual (keeping the master wrap) instead of
+    /// locking the device out. This is the core hardening guard.
     #[test]
-    fn inlined_not_all_capable_downgrades_per_device_to_dual() {
+    fn host_all_capable_true_with_malformed_recipient_redrives_false_in_rust() {
+        let good = tcfs_secrets::device::generate_local_device_key();
+        let secret = good.secret_key.expose_secret().to_string();
+        // Precondition: confirm the keys are what we expect — one real, one not.
+        assert!(tcfs_secrets::device::is_real_age_public_key(
+            &good.public_key
+        ));
+        let bogus = "age1-this-is-not-a-real-bech32-age-recipient-key-000000";
+        assert!(
+            !tcfs_secrets::device::is_real_age_public_key(bogus),
+            "bogus recipient must fail the real age parse"
+        );
+
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": good.public_key },
+                { "device_id": "device-b", "recipient": bogus }
+            ],
+            // Host LIES (over-counts via its heuristic): claims all capable.
+            "device_recipients_all_capable": true,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        // The malformed recipient is dropped from the wrap set...
+        assert_eq!(
+            ctx.device_recipients.len(),
+            1,
+            "malformed inlined recipient must be dropped by Rust re-validation"
+        );
+        assert_eq!(ctx.device_recipients[0].device_id, "device-a");
+        // ...and all_capable is re-derived to false (1 of 2 failed), so despite
+        // the host's all_capable=true we must NOT drop the master wrap.
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::Dual,
+            "host all_capable=true must be IGNORED; Rust re-derivation -> Dual, \
+             keeping the master wrap (no lockout)"
+        );
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// The inlined `device_recipients_all_capable=false` signal must NOT be able
+    /// to FORCE all_capable when Rust re-derivation says every inlined recipient
+    /// is well-formed. Re-derivation is authoritative: with a single valid
+    /// recipient (1 of 1 parsed) all_capable re-derives TRUE and PerDevice is
+    /// kept, even though the host asserted `false`. (The host boolean is not
+    /// trusted in EITHER direction.)
+    #[test]
+    fn host_all_capable_false_is_overridden_by_rust_when_recipients_well_formed() {
         let key = tcfs_secrets::device::generate_local_device_key();
         let secret = key.secret_key.expose_secret().to_string();
         let config = serde_json::json!({
@@ -646,14 +736,16 @@ mod tests {
             "device_recipients": [
                 { "device_id": "device-a", "recipient": key.public_key }
             ],
+            // Host asserts NOT all capable; Rust re-derivation disagrees.
             "device_recipients_all_capable": false,
             "device_secret": secret,
         });
         let ctx = build_encryption_context(&config, "device-a", &master());
         assert_eq!(
             ctx.wrap_mode,
-            tcfs_sync::engine::WrapMode::Dual,
-            "all_capable=false must downgrade PerDevice -> Dual"
+            tcfs_sync::engine::WrapMode::PerDevice,
+            "Rust re-derivation (1 of 1 well-formed) -> all_capable=true; host \
+             false is not trusted"
         );
         assert_eq!(ctx.device_recipients.len(), 1);
         assert!(ctx.device_identity.is_some());

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -81,38 +81,66 @@ fn wrap_mode_from_config(config: &serde_json::Value) -> tcfs_core::config::WrapM
     }
 }
 
-/// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
-/// mirroring `tcfsd`'s `build_encryption_context`.
+/// Resolve the active per-device recipient set, PREFERRING values inlined into
+/// the config over an on-disk registry read (TIN-1417 Keychain inlining).
 ///
-/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
-/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
-/// `per_device_wrapping: true` alias). In that case it loads the device registry
-/// plus this device's age secret and attaches them, like the daemon, and applies
-/// the same roll-call gate (PerDevice downgrades to Dual unless every active
-/// device has a real age recipient).
+/// Under the macOS FileProvider sandbox the `.appex` cannot `fs`-read
+/// `~/.config/tcfs` (where the device registry lives); it receives its config
+/// from the shared Keychain instead. The Swift host therefore inlines the
+/// already-VERIFIED active recipients into the Keychain config copy under
+/// `device_recipients`, exactly mirroring how it inlines `master_key_base64`.
+/// When that key is present we trust it verbatim and never touch the filesystem;
+/// otherwise we fall back to loading `devices.json` (the non-sandboxed path used
+/// by the daemon/CLI and by tests).
 ///
-/// Like the daemon, this falls back to the master-only context (and logs why)
-/// only when per-device wrapping is requested but the registry/recipients/secret
-/// are unavailable — it never produces a context that this device cannot read
-/// back. The engine's read switch independently fails CLOSED if it then meets a
-/// per-device manifest with no identity attached.
+/// Returns `(recipients, all_capable)`. `all_capable` reflects whether every
+/// active device carries a real age recipient — for the inlined path it is
+/// supplied by the host under `device_recipients_all_capable` (the host runs the
+/// same roll-call against the verified registry); for the fs path it is derived
+/// from the loaded registry's `roll_call()`. It gates the PerDevice contract
+/// mode exactly as the daemon's roll-call gate does.
 #[cfg(feature = "grpc")]
-pub(crate) fn build_encryption_context(
+fn resolve_recipients(
     config: &serde_json::Value,
-    device_id: &str,
-    master_key: &tcfs_crypto::MasterKey,
-) -> tcfs_sync::engine::EncryptionContext {
-    use tcfs_core::config::WrapMode;
-    use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
-
-    let base = EncryptionContext::new(master_key.clone());
-
-    // Default-off: byte-identical master-only behavior unless explicitly enabled.
-    let requested = wrap_mode_from_config(config);
-    if requested == WrapMode::Master {
-        return base;
+    requested: tcfs_core::config::WrapMode,
+) -> Option<(Vec<tcfs_crypto::AgeFileKeyRecipient>, bool)> {
+    // Inlined-first: the Keychain-provided config copy carries the verified
+    // active recipients so the sandboxed FileProvider never reads devices.json.
+    if let Some(arr) = config
+        .get("device_recipients")
+        .and_then(serde_json::Value::as_array)
+    {
+        let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = arr
+            .iter()
+            .filter_map(|entry| {
+                let device_id = entry.get("device_id")?.as_str()?.to_string();
+                let recipient = entry.get("recipient")?.as_str()?.to_string();
+                if !tcfs_secrets::device::is_real_age_public_key(&recipient) {
+                    return None;
+                }
+                Some(tcfs_crypto::AgeFileKeyRecipient {
+                    device_id,
+                    recipient,
+                })
+            })
+            .collect();
+        if recipients.is_empty() {
+            tracing::warn!(
+                "wrap_mode={requested:?}: inlined device_recipients present but empty/invalid; \
+                 using master wrap"
+            );
+            return None;
+        }
+        // The host computes capability against the verified registry; default to
+        // false (no PerDevice drop) when the signal is absent.
+        let all_capable = config
+            .get("device_recipients_all_capable")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        return Some((recipients, all_capable));
     }
 
+    // FS fallback (non-sandboxed daemon/CLI/test path): load the registry.
     let registry_path = config
         .get("device_registry_path")
         .and_then(serde_json::Value::as_str)
@@ -125,7 +153,7 @@ pub(crate) fn build_encryption_context(
             tracing::warn!(
                 "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
             );
-            return base;
+            return None;
         }
     };
 
@@ -141,36 +169,122 @@ pub(crate) fn build_encryption_context(
         tracing::warn!(
             "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
-        return base;
+        return None;
     }
 
+    let all_capable = registry.roll_call().all_capable();
+    Some((recipients, all_capable))
+}
+
+/// Resolve THIS device's age unwrap identity, PREFERRING a secret inlined into
+/// the config over an on-disk `device-<id>.age` read (TIN-1417 Keychain
+/// inlining).
+///
+/// The macOS FileProvider `.appex` cannot `fs`-read `device-<id>.age`, so the
+/// Swift host inlines this device's armored age secret into the Keychain config
+/// copy under `device_secret`, mirroring `master_key_base64`. When present we use
+/// it verbatim; otherwise we fall back to reading `device-<id>.age` from disk
+/// (the daemon/CLI/test path).
+#[cfg(feature = "grpc")]
+fn resolve_device_identity(
+    config: &serde_json::Value,
+    device_id: &str,
+    requested: tcfs_core::config::WrapMode,
+) -> Option<tcfs_sync::engine::DeviceUnwrapIdentity> {
+    use tcfs_sync::engine::DeviceUnwrapIdentity;
+
+    // Inlined-first: prefer the Keychain-provided secret over the fs read.
+    if let Some(secret) = config
+        .get("device_secret")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+    {
+        return Some(DeviceUnwrapIdentity {
+            device_id: device_id.to_string(),
+            secret: secret.trim().to_string(),
+        });
+    }
+
+    // FS fallback: read device-<id>.age relative to the registry path.
+    let registry_path = config
+        .get("device_registry_path")
+        .and_then(serde_json::Value::as_str)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(tcfs_secrets::device::default_registry_path);
     let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
-    let identity = match std::fs::read_to_string(&secret_path) {
-        Ok(s) => DeviceUnwrapIdentity {
+    match std::fs::read_to_string(&secret_path) {
+        Ok(s) => Some(DeviceUnwrapIdentity {
             device_id: device_id.to_string(),
             secret: s.trim().to_string(),
-        },
+        }),
         Err(e) => {
             tracing::warn!(
                 "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
-            return base;
+            None
         }
+    }
+}
+
+/// Build a DEVICE-AWARE `EncryptionContext` for the FileProvider read path,
+/// mirroring `tcfsd`'s `build_encryption_context`.
+///
+/// Default-off invariant: returns `EncryptionContext::new(master_key)` verbatim
+/// unless the config selects a non-`Master` `wrap_mode` (or the legacy
+/// `per_device_wrapping: true` alias). In that case it resolves the active
+/// recipient set plus this device's age secret and attaches them, like the
+/// daemon, and applies the same roll-call gate (PerDevice downgrades to Dual
+/// unless every active device has a real age recipient).
+///
+/// SANDBOX (TIN-1417): both the recipient set and this device's secret are
+/// resolved INLINED-FIRST — preferring values the Swift host wrote into the
+/// shared-Keychain config copy (`device_recipients` / `device_secret`) over an
+/// on-disk read of `devices.json` / `device-<id>.age`. The macOS FileProvider
+/// `.appex` cannot `fs`-read `~/.config/tcfs`, so the inlined path is the only
+/// one that works in-sandbox; the fs path remains the fallback for the
+/// non-sandboxed daemon/CLI and for tests.
+///
+/// Like the daemon, this falls back to the master-only context (and logs why)
+/// only when per-device wrapping is requested but the registry/recipients/secret
+/// are unavailable — it never produces a context that this device cannot read
+/// back. The engine's read switch independently fails CLOSED if it then meets a
+/// per-device manifest with no identity attached.
+#[cfg(feature = "grpc")]
+pub(crate) fn build_encryption_context(
+    config: &serde_json::Value,
+    device_id: &str,
+    master_key: &tcfs_crypto::MasterKey,
+) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
+    use tcfs_sync::engine::EncryptionContext;
+
+    let base = EncryptionContext::new(master_key.clone());
+
+    // Default-off: byte-identical master-only behavior unless explicitly enabled.
+    let requested = wrap_mode_from_config(config);
+    if requested == WrapMode::Master {
+        return base;
+    }
+
+    let (recipients, all_capable) = match resolve_recipients(config, requested) {
+        Some(v) => v,
+        None => return base,
+    };
+
+    let identity = match resolve_device_identity(config, device_id, requested) {
+        Some(id) => id,
+        None => return base,
     };
 
     // Roll-call gate: refuse PerDevice (drop master wrap) unless every active
     // device is per-device-capable; otherwise degrade to Dual + warn.
     let effective = if requested == WrapMode::PerDevice {
-        let roll_call = registry.roll_call();
-        if roll_call.all_capable() {
+        if all_capable {
             WrapMode::PerDevice
         } else {
             tracing::warn!(
-                active = roll_call.active,
-                capable = roll_call.capable,
-                blockers = ?roll_call.incapable_devices,
-                "wrap_mode=PerDevice REFUSED by roll-call gate; falling back to Dual \
-                 (keeping the master wrap)"
+                "wrap_mode=PerDevice REFUSED by roll-call gate (not all active devices \
+                 carry a real age recipient); falling back to Dual (keeping the master wrap)"
             );
             WrapMode::Dual
         }
@@ -184,6 +298,7 @@ pub(crate) fn build_encryption_context(
 #[cfg(all(test, feature = "grpc"))]
 mod tests {
     use super::*;
+    use secrecy::ExposeSecret;
     use tcfs_secrets::device::{DeviceIdentity, DeviceRegistry};
 
     fn master() -> tcfs_crypto::MasterKey {
@@ -473,6 +588,146 @@ mod tests {
         .await
         .expect("default FP context must read master-only manifest unchanged");
         assert_eq!(std::fs::read(&dst).unwrap(), content);
+    }
+
+    /// SANDBOX (TIN-1417): the INLINED Keychain-config path is preferred over any
+    /// fs read. With `device_recipients` + `device_secret` inlined and NO
+    /// registry/secret on disk (and a deliberately bogus `device_registry_path`),
+    /// the context still attaches recipients + this device's identity — proving
+    /// the FileProvider `.appex` can build a device-aware context without ever
+    /// touching `~/.config/tcfs`.
+    #[test]
+    fn inlined_recipients_and_secret_are_preferred_without_fs() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            // Point at a path that does NOT exist on disk to prove no fs read
+            // happens when the inlined values are present.
+            "device_registry_path": "/nonexistent/tcfs/devices.json",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": key.public_key }
+            ],
+            "device_recipients_all_capable": true,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::PerDevice,
+            "inlined all_capable=true should keep PerDevice"
+        );
+        assert_eq!(
+            ctx.device_recipients.len(),
+            1,
+            "inlined recipient set must be used"
+        );
+        assert_eq!(ctx.device_recipients[0].device_id, "device-a");
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("inlined secret must attach a device identity");
+        assert_eq!(identity.device_id, "device-a");
+        assert_eq!(
+            identity.secret, secret,
+            "inlined secret must be used verbatim (no fs read)"
+        );
+    }
+
+    /// The inlined `device_recipients_all_capable=false` signal trips the same
+    /// roll-call gate as the fs path: PerDevice downgrades to Dual (keeping the
+    /// master wrap) even though recipients + secret are present.
+    #[test]
+    fn inlined_not_all_capable_downgrades_per_device_to_dual() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": key.public_key }
+            ],
+            "device_recipients_all_capable": false,
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(
+            ctx.wrap_mode,
+            tcfs_sync::engine::WrapMode::Dual,
+            "all_capable=false must downgrade PerDevice -> Dual"
+        );
+        assert_eq!(ctx.device_recipients.len(), 1);
+        assert!(ctx.device_identity.is_some());
+    }
+
+    /// The fs path is the FALLBACK: when no inlined values are present the context
+    /// is built from `devices.json` + `device-<id>.age` exactly as before. This is
+    /// the daemon/CLI/non-sandboxed path. (Regression guard that inlining did not
+    /// break the on-disk path.)
+    #[test]
+    fn fs_path_is_used_as_fallback_when_not_inlined() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _pub = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("fs fallback must attach a device identity");
+        assert!(identity.secret.starts_with("AGE-SECRET-KEY-"));
+    }
+
+    /// Mixed precedence: inlined recipients but NO inlined secret -> the secret is
+    /// resolved via the fs fallback. Proves the two resolvers are independent and
+    /// each is inlined-first / fs-fallback on its own.
+    #[test]
+    fn inlined_recipients_with_fs_secret_fallback() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pub_key = provision_device(tmp.path(), "device-a");
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": tmp.path().join("devices.json").to_str().unwrap(),
+            "device_recipients": [
+                { "device_id": "device-a", "recipient": pub_key }
+            ],
+            "device_recipients_all_capable": true,
+            // No device_secret -> falls back to reading device-a.age from disk.
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert_eq!(ctx.wrap_mode, tcfs_sync::engine::WrapMode::PerDevice);
+        assert_eq!(ctx.device_recipients.len(), 1);
+        let identity = ctx
+            .device_identity
+            .as_ref()
+            .expect("secret should resolve via fs fallback");
+        assert!(identity.secret.starts_with("AGE-SECRET-KEY-"));
+    }
+
+    /// Inlined `device_secret` present but recipients absent and no on-disk
+    /// registry -> recipient resolution fails, so the context fails back to
+    /// master-only (never a half-wired identity-only context). Fail-safe.
+    #[test]
+    fn inlined_secret_without_recipients_falls_back_to_master() {
+        let key = tcfs_secrets::device::generate_local_device_key();
+        let secret = key.secret_key.expose_secret().to_string();
+        let config = serde_json::json!({
+            "wrap_mode": "per_device",
+            "device_registry_path": "/nonexistent/tcfs/devices.json",
+            "device_secret": secret,
+        });
+        let ctx = build_encryption_context(&config, "device-a", &master());
+        assert!(
+            ctx.device_recipients.is_empty(),
+            "no recipients resolvable -> master-only"
+        );
+        assert!(
+            ctx.device_identity.is_none(),
+            "must not attach a half-wired identity-only context"
+        );
     }
 
     /// The fail-loud guard for the master-only backends rejects per-device

--- a/crates/tcfs-file-provider/src/device_ctx.rs
+++ b/crates/tcfs-file-provider/src/device_ctx.rs
@@ -882,6 +882,7 @@ mod tests {
             written_at: 0,
             rel_path: None,
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -395,9 +395,11 @@ pub unsafe extern "C" fn tcfs_provider_fetch(
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
 
-            // Fail CLOSED on per-device manifests: this direct backend only
-            // unwraps master-wrapped keys. A `wrapped_file_keys` manifest would
-            // otherwise fall through to "no file key" and copy raw ciphertext.
+            // Fail CLOSED on PerDevice/v3 manifests: this direct backend only
+            // unwraps master-wrapped keys. A `wrapped_file_keys` manifest with no
+            // master wrap would otherwise fall through to "no file key" and copy
+            // raw ciphertext. Dual/v2 (both wraps present) is permitted and read
+            // via the master wrap below (TIN-1898, mirrors the engine switch).
             crate::device_ctx::ensure_master_decryptable(&manifest)?;
 
             // Unwrap file key if E2EE manifest
@@ -521,7 +523,8 @@ pub unsafe extern "C" fn tcfs_provider_fetch_with_progress(
             let manifest =
                 tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes.to_bytes())?;
 
-            // Fail CLOSED on per-device manifests (see fetch path above).
+            // Fail CLOSED on PerDevice/v3 manifests only (see fetch path above);
+            // Dual/v2 reads via the master wrap (TIN-1898).
             crate::device_ctx::ensure_master_decryptable(&manifest)?;
 
             let file_key = match (&prov.master_key, &manifest.encrypted_file_key) {
@@ -1353,6 +1356,232 @@ mod tests {
             assert!(!item.is_directory);
 
             crate::tcfs_file_items_free(items, count);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    // ── TIN-1898: Dual/master-wrap fallback on the master-only direct backend ──
+    //
+    // The direct backend carries no per-device age identity. Mirroring the engine
+    // read switch (tcfs-sync/src/engine.rs ~:2395), a Dual/v2 manifest (BOTH a
+    // master `encrypted_file_key` AND `wrapped_file_keys`) must be READABLE here
+    // via the master wrap; a PerDevice/v3 manifest (wrapped_file_keys, NO master
+    // wrap) must stay strictly FAIL-CLOSED; a plain master-only manifest is
+    // unchanged.
+
+    /// Build a `TcfsProvider` over a caller-supplied operator + master key so the
+    /// test can seed the same in-memory store the provider reads from.
+    fn master_provider_on(
+        operator: opendal::Operator,
+        prefix: &str,
+        master_key: tcfs_crypto::MasterKey,
+    ) -> *mut TcfsProvider {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime");
+        Box::into_raw(Box::new(TcfsProvider {
+            runtime,
+            operator,
+            remote_prefix: prefix.to_string(),
+            device_id: "test-device".to_string(),
+            master_key: Some(master_key),
+            last_error: Mutex::new(None),
+        }))
+    }
+
+    /// Seed a single-chunk encrypted file under `prefix` for `rel`, returning the
+    /// FileKey-derived ciphertext layout. `include_master` toggles the master
+    /// `encrypted_file_key`; `include_wraps` toggles a `wrapped_file_keys` entry.
+    ///
+    /// Combinations:
+    /// - master only       -> (true,  false): plain v2 master manifest.
+    /// - dual              -> (true,  true) : v2 with BOTH wraps.
+    /// - per-device / v3   -> (false, true) : wrapped_file_keys, NO master wrap.
+    ///
+    /// The per-device wrap is a placeholder `WrappedFileKey` — the master-only
+    /// backend never attempts to unwrap it (it has no identity), exactly as in
+    /// production; only its presence/absence drives the guard decision.
+    fn seed_encrypted_file(
+        operator: &opendal::Operator,
+        prefix: &str,
+        rel: &str,
+        content: &[u8],
+        master_key: &tcfs_crypto::MasterKey,
+        include_master: bool,
+        include_wraps: bool,
+    ) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("seed runtime");
+        rt.block_on(async {
+            let file_hash = tcfs_chunks::hash_bytes(content);
+            let file_hash_hex = tcfs_chunks::hash_to_hex(&file_hash);
+            let file_id: [u8; 32] = *file_hash.as_bytes();
+
+            let file_key = tcfs_crypto::generate_file_key();
+            let encrypted =
+                tcfs_crypto::encrypt_chunk(&file_key, 0, &file_id, content).expect("encrypt chunk");
+            let chunk_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&encrypted));
+
+            // chunks/<hash> = encrypted chunk bytes
+            operator
+                .write(
+                    &format!("{}/chunks/{}", prefix.trim_end_matches('/'), chunk_hash),
+                    encrypted,
+                )
+                .await
+                .expect("write chunk");
+
+            let encrypted_file_key = if include_master {
+                let wrapped = tcfs_crypto::wrap_key(master_key, &file_key).expect("wrap master");
+                Some(base64::engine::general_purpose::STANDARD.encode(wrapped))
+            } else {
+                None
+            };
+            let wrapped_file_keys = if include_wraps {
+                // Placeholder per-device wrap: never unwrapped by this backend.
+                vec![tcfs_sync::manifest::WrappedFileKey {
+                    recipient_device_id: "device-b".to_string(),
+                    recipient: "age1placeholderrecipientnotparsedbymasterbackend".to_string(),
+                    algorithm: "age-x25519-file-key-v1".to_string(),
+                    wrapped_key: "PLACEHOLDER-WRAP".to_string(),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let manifest = tcfs_sync::manifest::SyncManifest {
+                // v3 iff per-device-only (no master wrap); else v2.
+                version: if include_wraps && !include_master {
+                    3
+                } else {
+                    2
+                },
+                file_hash: file_hash_hex.clone(),
+                file_size: content.len() as u64,
+                chunks: vec![chunk_hash],
+                vclock: tcfs_sync::conflict::VectorClock::default(),
+                written_by: "device-b".to_string(),
+                written_at: 0,
+                rel_path: Some(rel.to_string()),
+                mode: None,
+                encrypted_file_key,
+                wrapped_file_keys,
+            };
+
+            operator
+                .write(
+                    &format!(
+                        "{}/manifests/{}",
+                        prefix.trim_end_matches('/'),
+                        file_hash_hex
+                    ),
+                    manifest.to_bytes().expect("manifest bytes"),
+                )
+                .await
+                .expect("write manifest");
+
+            let index = tcfs_sync::index_entry::RemoteIndexEntry::new(
+                file_hash_hex,
+                content.len() as u64,
+                1,
+            );
+            operator
+                .write(
+                    &format!("{}/index/{}", prefix.trim_end_matches('/'), rel),
+                    index.to_legacy_bytes(),
+                )
+                .await
+                .expect("write index");
+        });
+    }
+
+    /// A Dual/v2 manifest (master + per-device wraps) is READABLE via the
+    /// master-only direct backend through the master wrap — fetch succeeds and
+    /// the plaintext round-trips. This is the core TIN-1898 fix.
+    #[test]
+    fn dual_manifest_reads_via_master_wrap_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "dual";
+        let content = b"dual manifest readable via master fallback on the FP direct backend";
+        seed_encrypted_file(&operator, prefix, "dual.txt", content, &master, true, true);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("dual.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_eq!(
+                err,
+                TcfsError::TcfsErrorNone,
+                "Dual manifest must be readable via the master wrap"
+            );
+            assert_eq!(std::fs::read(&dest).unwrap(), content);
+            tcfs_provider_free(prov);
+        }
+    }
+
+    /// A PerDevice/v3 manifest (wrapped_file_keys, NO master wrap) still FAILS
+    /// CLOSED on the master-only direct backend: fetch errors and no file is
+    /// materialized (never raw ciphertext).
+    #[test]
+    fn per_device_manifest_fails_closed_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "pd";
+        let content = b"per-device-only payload that the master-only backend cannot read";
+        seed_encrypted_file(&operator, prefix, "pd.txt", content, &master, false, true);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("pd.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_ne!(
+                err,
+                TcfsError::TcfsErrorNone,
+                "PerDevice/v3 manifest must FAIL CLOSED on the master-only backend"
+            );
+            assert!(
+                !dest.exists(),
+                "fail-closed fetch must not materialize a (corrupt) file"
+            );
+            tcfs_provider_free(prov);
+        }
+    }
+
+    /// A plain master-only manifest reads unchanged on the direct backend —
+    /// regression guard for the default `wrap_mode=master` path.
+    #[test]
+    fn master_only_manifest_reads_unchanged_on_direct_backend() {
+        let operator = opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "mo";
+        let content = b"plain master-only payload, unchanged";
+        seed_encrypted_file(&operator, prefix, "mo.txt", content, &master, true, false);
+
+        let prov = master_provider_on(operator, prefix, master);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        unsafe {
+            let c_item = CString::new("mo.txt").unwrap();
+            let c_dest = CString::new(dest.to_str().unwrap()).unwrap();
+            let err = tcfs_provider_fetch(prov, c_item.as_ptr(), c_dest.as_ptr());
+            assert_eq!(err, TcfsError::TcfsErrorNone);
+            assert_eq!(std::fs::read(&dest).unwrap(), content);
             tcfs_provider_free(prov);
         }
     }

--- a/crates/tcfs-file-provider/src/direct.rs
+++ b/crates/tcfs-file-provider/src/direct.rs
@@ -722,6 +722,7 @@ pub unsafe extern "C" fn tcfs_provider_upload(
                 written_at,
                 rel_path: Some(remote_str.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys: Vec::new(),
             };
@@ -1467,6 +1468,7 @@ mod tests {
                 written_at: 0,
                 rel_path: Some(rel.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys,
             };

--- a/crates/tcfs-file-provider/src/grpc_backend.rs
+++ b/crates/tcfs-file-provider/src/grpc_backend.rs
@@ -239,15 +239,25 @@ async fn fetch_direct_to_file(
             .with_context(|| format!("resolving manifest for: {remote_path}"))?;
 
     // Build the read context with this device's unwrap identity attached
-    // (TIN-1417). With the default config `device_recipients` is empty and
-    // `device_identity` is None, so `with_device_wrapping` is a no-op and this
-    // equals the prior `EncryptionContext::new(mk)` exactly (byte-identical for
-    // master-only manifests). When a per-device (`wrapped_file_keys`) manifest
-    // is read, the engine's read switch fails CLOSED with a clear error if no
+    // (TIN-1417). This is a READ path, so `wrap_mode` (which only drives the
+    // write path) is immaterial here — the engine's read switch branches on the
+    // manifest's own shape (`wrapped_file_keys` vs `encrypted_file_key`). With
+    // the default config `device_recipients` is empty and `device_identity` is
+    // None, so this equals `EncryptionContext::new(mk)` (byte-identical for
+    // master-only manifests). When a per-device (`wrapped_file_keys`) manifest is
+    // read, the engine's read switch fails CLOSED with a clear error if no
     // identity is attached — it never silently master-falls-back.
     let enc_ctx = master_key.as_ref().map(|mk| {
-        tcfs_sync::engine::EncryptionContext::new(mk.clone())
-            .with_device_wrapping(device_recipients, device_identity)
+        let mode = if device_recipients.is_empty() {
+            tcfs_sync::engine::WrapMode::Master
+        } else {
+            tcfs_sync::engine::WrapMode::PerDevice
+        };
+        tcfs_sync::engine::EncryptionContext::new(mk.clone()).with_wrap_mode(
+            mode,
+            device_recipients,
+            device_identity,
+        )
     });
 
     tcfs_sync::engine::download_file_with_device(

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -305,13 +305,16 @@ impl TcfsProviderHandle {
                 message: e.to_string(),
             })?;
 
-            // Fail CLOSED on per-device manifests: this backend only unwraps
-            // master-wrapped keys. A `wrapped_file_keys` manifest would
+            // Fail CLOSED on PerDevice/v3 manifests only: this backend unwraps
+            // master-wrapped keys only (no per-device age identity). A manifest
+            // with `wrapped_file_keys` AND no master `encrypted_file_key` would
             // otherwise fall through to "no file key" and copy raw ciphertext.
-            if !manifest.wrapped_file_keys.is_empty() {
+            // Dual/v2 manifests (both wraps present) are readable via the master
+            // wrap below, mirroring the engine read switch (TIN-1898).
+            if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
                 return Err(ProviderError::Decryption {
-                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
-                              this backend only supports master-key unwrapping"
+                    message: "manifest is per-device encrypted (wrapped_file_keys present, \
+                              no master wrap); this backend only supports master-key unwrapping"
                         .to_string(),
                 });
             }
@@ -412,11 +415,13 @@ impl TcfsProviderHandle {
                 message: e.to_string(),
             })?;
 
-            // Fail CLOSED on per-device manifests (see hydrate path above).
-            if !manifest.wrapped_file_keys.is_empty() {
+            // Fail CLOSED on PerDevice/v3 manifests only (see hydrate path above):
+            // Dual/v2 (both wraps) is readable via the master wrap; only a
+            // wrapped_file_keys manifest with NO master wrap is refused.
+            if !manifest.wrapped_file_keys.is_empty() && manifest.encrypted_file_key.is_none() {
                 return Err(ProviderError::Decryption {
-                    message: "manifest is per-device encrypted (wrapped_file_keys present); \
-                              this backend only supports master-key unwrapping"
+                    message: "manifest is per-device encrypted (wrapped_file_keys present, \
+                              no master wrap); this backend only supports master-key unwrapping"
                         .to_string(),
                 });
             }
@@ -881,9 +886,197 @@ fn verify_bootstrap_signature(
     Ok(diff == 0)
 }
 
+/// Test-only constructor: build a handle directly over a caller-supplied
+/// operator + optional master key, bypassing the S3/network constructor so
+/// unit tests can seed an in-memory store and exercise the read path.
+#[cfg(test)]
+impl TcfsProviderHandle {
+    fn new_for_test(
+        operator: opendal::Operator,
+        remote_prefix: &str,
+        master_key: Option<tcfs_crypto::MasterKey>,
+    ) -> Arc<Self> {
+        let runtime = tokio::runtime::Runtime::new().expect("test runtime");
+        Arc::new(Self {
+            runtime,
+            operator,
+            remote_prefix: remote_prefix.to_string(),
+            device_id: "ios-test".to_string(),
+            master_key,
+            #[cfg(feature = "uniffi")]
+            totp_provider: Arc::new(tcfs_auth::totp::TotpProvider::new(
+                tcfs_auth::totp::TotpConfig::default(),
+            )),
+            #[cfg(feature = "uniffi")]
+            session_store: tcfs_auth::SessionStore::new(),
+        })
+    }
+}
+
 #[cfg(all(test, feature = "uniffi"))]
 mod tests {
     use super::*;
+    use base64::Engine;
+
+    /// Seed a single-chunk encrypted file under `prefix` for `rel`. See the
+    /// direct-backend `seed_encrypted_file` for the layout rationale (TIN-1898).
+    /// `include_master`/`include_wraps` select master-only / dual / per-device.
+    fn seed_encrypted_file(
+        operator: &opendal::Operator,
+        prefix: &str,
+        rel: &str,
+        content: &[u8],
+        master_key: &tcfs_crypto::MasterKey,
+        include_master: bool,
+        include_wraps: bool,
+    ) {
+        let rt = tokio::runtime::Runtime::new().expect("seed runtime");
+        rt.block_on(async {
+            let file_hash = tcfs_chunks::hash_bytes(content);
+            let file_hash_hex = tcfs_chunks::hash_to_hex(&file_hash);
+            let file_id: [u8; 32] = *file_hash.as_bytes();
+
+            let file_key = tcfs_crypto::generate_file_key();
+            let encrypted =
+                tcfs_crypto::encrypt_chunk(&file_key, 0, &file_id, content).expect("encrypt chunk");
+            let chunk_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&encrypted));
+
+            operator
+                .write(
+                    &format!("{}/chunks/{}", prefix.trim_end_matches('/'), chunk_hash),
+                    encrypted,
+                )
+                .await
+                .expect("write chunk");
+
+            let encrypted_file_key = if include_master {
+                let wrapped = tcfs_crypto::wrap_key(master_key, &file_key).expect("wrap master");
+                Some(base64::engine::general_purpose::STANDARD.encode(wrapped))
+            } else {
+                None
+            };
+            let wrapped_file_keys = if include_wraps {
+                vec![tcfs_sync::manifest::WrappedFileKey {
+                    recipient_device_id: "device-b".to_string(),
+                    recipient: "age1placeholderrecipientnotparsedbymasterbackend".to_string(),
+                    algorithm: "age-x25519-file-key-v1".to_string(),
+                    wrapped_key: "PLACEHOLDER-WRAP".to_string(),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let manifest = tcfs_sync::manifest::SyncManifest {
+                version: if include_wraps && !include_master {
+                    3
+                } else {
+                    2
+                },
+                file_hash: file_hash_hex.clone(),
+                file_size: content.len() as u64,
+                chunks: vec![chunk_hash],
+                vclock: tcfs_sync::conflict::VectorClock::default(),
+                written_by: "device-b".to_string(),
+                written_at: 0,
+                rel_path: Some(rel.to_string()),
+                mode: None,
+                encrypted_file_key,
+                wrapped_file_keys,
+            };
+
+            operator
+                .write(
+                    &format!(
+                        "{}/manifests/{}",
+                        prefix.trim_end_matches('/'),
+                        file_hash_hex
+                    ),
+                    manifest.to_bytes().expect("manifest bytes"),
+                )
+                .await
+                .expect("write manifest");
+
+            let index = tcfs_sync::index_entry::RemoteIndexEntry::new(
+                file_hash_hex,
+                content.len() as u64,
+                1,
+            );
+            operator
+                .write(
+                    &format!("{}/index/{}", prefix.trim_end_matches('/'), rel),
+                    index.to_legacy_bytes(),
+                )
+                .await
+                .expect("write index");
+        });
+    }
+
+    fn memory_operator() -> opendal::Operator {
+        opendal::Operator::new(opendal::services::Memory::default())
+            .expect("memory operator")
+            .finish()
+    }
+
+    /// TIN-1898: a Dual/v2 manifest (master + per-device wraps) is READABLE via
+    /// the master-only uniffi backend through the master wrap.
+    #[test]
+    fn dual_manifest_reads_via_master_wrap_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "dual";
+        let content = b"dual manifest readable via master fallback on the uniffi backend";
+        seed_encrypted_file(&operator, prefix, "dual.txt", content, &master, true, true);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        handle
+            .hydrate_file(&format!("{prefix}/index/dual.txt"), dest.to_str().unwrap())
+            .expect("Dual manifest must hydrate via the master wrap");
+        assert_eq!(std::fs::read(&dest).unwrap(), content);
+    }
+
+    /// TIN-1898: a PerDevice/v3 manifest (wrapped_file_keys, NO master wrap)
+    /// still FAILS CLOSED on the master-only uniffi backend and writes no file.
+    #[test]
+    fn per_device_manifest_fails_closed_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "pd";
+        let content = b"per-device-only payload the uniffi master backend cannot read";
+        seed_encrypted_file(&operator, prefix, "pd.txt", content, &master, false, true);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        let res = handle.hydrate_file(&format!("{prefix}/index/pd.txt"), dest.to_str().unwrap());
+        assert!(
+            matches!(res, Err(ProviderError::Decryption { .. })),
+            "PerDevice/v3 must FAIL CLOSED with a Decryption error, got {res:?}"
+        );
+        assert!(
+            !dest.exists(),
+            "fail-closed hydrate must not materialize a (corrupt) file"
+        );
+    }
+
+    /// A plain master-only manifest reads unchanged on the uniffi backend.
+    #[test]
+    fn master_only_manifest_reads_unchanged_on_uniffi_backend() {
+        let operator = memory_operator();
+        let master = tcfs_crypto::MasterKey::from_bytes([9u8; tcfs_crypto::KEY_SIZE]);
+        let prefix = "mo";
+        let content = b"plain master-only payload, unchanged (uniffi)";
+        seed_encrypted_file(&operator, prefix, "mo.txt", content, &master, true, false);
+
+        let handle = TcfsProviderHandle::new_for_test(operator, prefix, Some(master));
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+        handle
+            .hydrate_file(&format!("{prefix}/index/mo.txt"), dest.to_str().unwrap())
+            .expect("master-only manifest must hydrate unchanged");
+        assert_eq!(std::fs::read(&dest).unwrap(), content);
+    }
 
     fn test_provider() -> Arc<TcfsProviderHandle> {
         TcfsProviderHandle::new(ProviderConfig {

--- a/crates/tcfs-file-provider/src/uniffi_bridge.rs
+++ b/crates/tcfs-file-provider/src/uniffi_bridge.rs
@@ -593,6 +593,7 @@ impl TcfsProviderHandle {
                 written_at,
                 rel_path: Some(remote_path.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys: Vec::new(),
             };
@@ -980,6 +981,7 @@ mod tests {
                 written_at: 0,
                 rel_path: Some(rel.to_string()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key,
                 wrapped_file_keys,
             };

--- a/crates/tcfs-mcp/src/server.rs
+++ b/crates/tcfs-mcp/src/server.rs
@@ -857,6 +857,9 @@ mod tests {
                     description: Some("primary".into()),
                     enrolled_at: 1,
                     revoked: false,
+                    revoked_at: None,
+                    enrolled_by: None,
+                    signing_pubkey: None,
                     last_nats_seq: 7,
                 },
                 tcfs_secrets::device::DeviceIdentity {
@@ -867,9 +870,15 @@ mod tests {
                     description: None,
                     enrolled_at: 2,
                     revoked: true,
+                    revoked_at: Some(2),
+                    enrolled_by: None,
+                    signing_pubkey: None,
                     last_nats_seq: 3,
                 },
             ],
+            registry_signature: None,
+            signer_pubkey: None,
+            sig_alg: None,
         };
         registry.save(&registry_path).unwrap();
 

--- a/crates/tcfs-secrets/Cargo.toml
+++ b/crates/tcfs-secrets/Cargo.toml
@@ -29,6 +29,9 @@ hostname = "0.4"
 uuid = { workspace = true }
 blake3 = { workspace = true }
 opendal = { workspace = true }
+ed25519-dalek = { workspace = true }
+hkdf = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -1,13 +1,46 @@
 //! Device identity management for multi-device E2E encryption.
 //!
-//! Each device gets its own age X25519 keypair, signed by the master identity.
-//! Device keys are stored in the platform keychain or an age-encrypted file.
+//! Each device gets its own age X25519 keypair. Device secret keys are stored in
+//! the platform keychain or an owner-only age-encrypted file.
+//!
+//! ## Registry integrity (TIN-1417 B4)
+//!
+//! The *registry itself* (the list of devices, which doubles as the per-device
+//! age **recipient set**) is the high-value attack surface: anyone with direct
+//! object-store write access to `meta_prefix/tcfs-meta/devices.json` could inject
+//! a hostile recipient, un-revoke a device, or drop a device. To make per-device
+//! revocation trustworthy the registry is wrapped in an **Ed25519 signature** over
+//! a canonical serialization of the device list.
+//!
+//! The signing key is *derived deterministically from the master key* via
+//! HKDF-SHA256 (domain `tcfs-device-registry-signing-v1`), so any master-key
+//! holder can sign and verify without distributing new key material. The
+//! signature and the signer's Ed25519 verifying key are stored alongside the
+//! device list in the same JSON object (see [`SIGNATURE_FIELD`]). Old (unsigned)
+//! registries still deserialize for a bounded back-compat migration window, but
+//! the recipient-set builders refuse to wrap to recipients from a registry that
+//! fails verification — they fall back to the shared master wrap instead.
+//!
+//! `signing_key_hash` on a [`DeviceIdentity`] is a BLAKE3 self-fingerprint of the
+//! device's *own* public key — it is NOT a signature and conveys no authority.
 
 use anyhow::{Context, Result};
+use base64::Engine as _;
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+
+/// HKDF info string domain-separating the registry-signing key from every other
+/// master-derived key. Changing this string rotates every registry signature.
+const REGISTRY_SIGNING_INFO: &[u8] = b"tcfs-device-registry-signing-v1";
+
+/// Signature algorithm tag stored in the envelope. Lets future versions migrate.
+const REGISTRY_SIG_ALG: &str = "ed25519-hkdf-sha256-v1";
+
+/// JSON field that carries the base64 Ed25519 signature in the on-disk envelope.
+pub const SIGNATURE_FIELD: &str = "registry_signature";
 
 /// A registered device identity
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -29,6 +62,23 @@ pub struct DeviceIdentity {
     pub enrolled_at: u64,
     /// Whether this device is revoked
     pub revoked: bool,
+    /// Unix timestamp at which this device was revoked, if any (TIN-1417 B4).
+    /// `None` for active devices and for legacy entries revoked before this field
+    /// existed; set by [`DeviceRegistry::revoke`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revoked_at: Option<u64>,
+    /// Ed25519 verifying key of the device that enrolled this one, base64
+    /// (TIN-1417 B4). Optional/forward-looking: lets a future per-event signed
+    /// log attribute enrollment. `None` on legacy entries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrolled_by: Option<String>,
+    /// This device's own Ed25519 signing public key, base64 (TIN-1417 B4).
+    /// Reserved for a future per-device append-only signed-event log; the SEV-1
+    /// fix signs the *whole registry* with the master-derived key, so this is
+    /// `None` today and carries no authority when present. `#[serde(default)]`
+    /// keeps legacy registries parseable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_pubkey: Option<String>,
     /// Last NATS JetStream sequence processed by this device
     #[serde(default)]
     pub last_nats_seq: u64,
@@ -57,11 +107,67 @@ impl RollCall {
     }
 }
 
-/// Device registry: tracks all enrolled devices for this user
+/// Device registry: tracks all enrolled devices for this user.
+///
+/// The registry is the per-device age **recipient set**, so its integrity is
+/// security-critical (TIN-1417 B4). When persisted it is wrapped in an Ed25519
+/// signature (see [`DeviceRegistry::sign`] / [`DeviceRegistry::verify_signature`]);
+/// the signature and signer pubkey live in `registry_signature` / `signer_pubkey`
+/// and are deliberately excluded from the signed payload so they can be (re)written
+/// without invalidating the signature over the device list.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeviceRegistry {
     /// List of enrolled devices
     pub devices: Vec<DeviceIdentity>,
+    /// Base64 Ed25519 signature over the canonical device list (TIN-1417 B4).
+    /// `None` for an unsigned/legacy registry. Not part of the signed payload.
+    #[serde(
+        default,
+        rename = "registry_signature",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub registry_signature: Option<String>,
+    /// Base64 Ed25519 verifying key of whoever signed the registry (the
+    /// master-derived signer). Bound into verification: a signature that verifies
+    /// against an *unexpected* signer is still rejected. Not part of the signed
+    /// payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer_pubkey: Option<String>,
+    /// Signature algorithm tag, e.g. `ed25519-hkdf-sha256-v1`. Not part of the
+    /// signed payload (the algorithm is implied by the verifier).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sig_alg: Option<String>,
+}
+
+/// Outcome of verifying a loaded registry against the master-derived signer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryTrust {
+    /// Envelope carried a valid signature from the expected master-derived signer.
+    Signed,
+    /// Legacy registry with no signature. Accepted only inside the migration
+    /// window; callers must treat its recipient set as UNVERIFIED.
+    UnsignedLegacy,
+}
+
+/// HKDF-derive the deterministic Ed25519 registry-signing key from the master key.
+///
+/// Domain-separated by [`REGISTRY_SIGNING_INFO`] so it is independent of the
+/// manifest/name keys. Every master-key holder derives the same signer, so no new
+/// key distribution is required to sign or verify the registry.
+fn registry_signing_key(master_key_bytes: &[u8; 32]) -> SigningKey {
+    let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, master_key_bytes);
+    let mut seed = [0u8; 32];
+    // HKDF-Expand into 32 bytes never fails for this length.
+    hk.expand(REGISTRY_SIGNING_INFO, &mut seed)
+        .expect("HKDF expand into 32 bytes is infallible");
+    let key = SigningKey::from_bytes(&seed);
+    seed.fill(0);
+    key
+}
+
+/// Base64 (standard, padded) helper used for signatures and keys.
+fn b64() -> base64::engine::general_purpose::GeneralPurpose {
+    base64::engine::general_purpose::STANDARD
 }
 
 /// Newly generated local device key material.
@@ -75,7 +181,11 @@ pub struct LocalDeviceKey {
 }
 
 impl DeviceRegistry {
-    /// Load device registry from a JSON file
+    /// Load device registry from a JSON file (no signature verification).
+    ///
+    /// Retained for non-crypto callers (e.g. `tcfs device list`, status probes)
+    /// that have no master key. Security-sensitive callers that build a per-device
+    /// **recipient set** MUST use [`DeviceRegistry::load_verified`] instead.
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
             return Ok(Self::default());
@@ -86,7 +196,45 @@ impl DeviceRegistry {
             .with_context(|| format!("parsing device registry: {}", path.display()))
     }
 
-    /// Save device registry to a JSON file
+    /// Load a registry from a JSON file AND verify its signature (TIN-1417 B4).
+    ///
+    /// Returns the registry plus its [`RegistryTrust`]. A present-but-invalid
+    /// signature (tampered device list, un-revoked entry, injected recipient, or a
+    /// signature from a non-master-derived key) is a HARD error. A registry with
+    /// no signature loads as [`RegistryTrust::UnsignedLegacy`] (migration window)
+    /// — callers MUST NOT build a per-device recipient set from an unsigned
+    /// registry. A missing file is an empty, signed-by-construction registry.
+    pub fn load_verified(
+        path: &Path,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<(Self, RegistryTrust)> {
+        if !path.exists() {
+            return Ok((Self::default(), RegistryTrust::Signed));
+        }
+        let reg = Self::load(path)?;
+        let trust = reg.verify_signature(master_key_bytes).with_context(|| {
+            format!(
+                "verifying device registry signature: {} (refusing to trust a tampered registry)",
+                path.display()
+            )
+        })?;
+        if trust == RegistryTrust::UnsignedLegacy {
+            tracing::warn!(
+                path = %path.display(),
+                "device registry is UNSIGNED (legacy). Accepting inside the TIN-1417 B4 \
+                 migration window, but its recipient set is UNVERIFIED and will not be used \
+                 for per-device wrapping. Re-save with a master-key-holding command to sign it."
+            );
+        }
+        Ok((reg, trust))
+    }
+
+    /// Save device registry to a JSON file.
+    ///
+    /// NOTE: this writes whatever signature envelope is currently on `self`. To
+    /// produce a *freshly signed* registry use [`DeviceRegistry::save_signed`],
+    /// which signs with the master-derived key before writing. Raw `save` is
+    /// retained for non-crypto callers and round-trips an existing envelope.
     pub fn save(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)
@@ -104,6 +252,16 @@ impl DeviceRegistry {
         Ok(())
     }
 
+    /// Sign with the master-derived key, then persist to a JSON file (TIN-1417 B4).
+    ///
+    /// This is the preferred writer for any mutating command: it guarantees the
+    /// on-disk registry carries a fresh, valid signature so subsequent
+    /// verification (load-side and recipient-set builders) succeeds.
+    pub fn save_signed(&mut self, path: &Path, master_key_bytes: &[u8; 32]) -> Result<()> {
+        self.sign(master_key_bytes)?;
+        self.save(path)
+    }
+
     /// Add a new device
     pub fn add(&mut self, device: DeviceIdentity) {
         self.devices.push(device);
@@ -112,6 +270,110 @@ impl DeviceRegistry {
     /// List active (non-revoked) devices
     pub fn active_devices(&self) -> impl Iterator<Item = &DeviceIdentity> {
         self.devices.iter().filter(|d| !d.revoked)
+    }
+
+    // ── TIN-1417 B4: registry signing / verification ─────────────────────────
+
+    /// Build the canonical, deterministic byte string that is signed.
+    ///
+    /// Independent of map/field ordering, of the envelope fields (signature,
+    /// signer pubkey, alg) and of pretty-printing: it serializes a *sorted* copy
+    /// of the device list to canonical JSON. Two registries with the same device
+    /// set (regardless of insertion order or signature) produce identical bytes,
+    /// so the signature is stable and tamper-evident.
+    fn canonical_signing_payload(&self) -> Result<Vec<u8>> {
+        let mut devices = self.devices.clone();
+        // Deterministic order: by device_id, then name (stable for empty ids).
+        devices.sort_by(|a, b| {
+            a.device_id
+                .cmp(&b.device_id)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        // serde_json serializes struct fields in declaration order, giving a
+        // canonical encoding for a fixed schema. Domain-prefix the algorithm tag
+        // so a signature can never be replayed under a different scheme.
+        let body = serde_json::to_vec(&devices).context("serializing canonical device list")?;
+        let mut msg = Vec::with_capacity(body.len() + REGISTRY_SIG_ALG.len() + 1);
+        msg.extend_from_slice(REGISTRY_SIG_ALG.as_bytes());
+        msg.push(0u8);
+        msg.extend_from_slice(&body);
+        Ok(msg)
+    }
+
+    /// Sign the registry with the master-derived Ed25519 key (TIN-1417 B4).
+    ///
+    /// Populates `registry_signature`, `signer_pubkey` and `sig_alg`. Idempotent:
+    /// re-signing an unchanged device list reproduces the same signature.
+    pub fn sign(&mut self, master_key_bytes: &[u8; 32]) -> Result<()> {
+        let signing_key = registry_signing_key(master_key_bytes);
+        let payload = self.canonical_signing_payload()?;
+        let sig: Signature = signing_key.sign(&payload);
+        let verifying: VerifyingKey = signing_key.verifying_key();
+        self.registry_signature = Some(b64().encode(sig.to_bytes()));
+        self.signer_pubkey = Some(b64().encode(verifying.to_bytes()));
+        self.sig_alg = Some(REGISTRY_SIG_ALG.to_string());
+        Ok(())
+    }
+
+    /// Verify the registry signature against the master-derived signer.
+    ///
+    /// Returns [`RegistryTrust::Signed`] on a valid signature from the expected
+    /// (master-derived) signer. Returns [`RegistryTrust::UnsignedLegacy`] for a
+    /// registry that carries NO signature (migration window). Returns a hard
+    /// `Err` when a signature is present but does not verify, is malformed, or was
+    /// produced by an unexpected (non-master-derived) signer — i.e. tampering.
+    pub fn verify_signature(&self, master_key_bytes: &[u8; 32]) -> Result<RegistryTrust> {
+        let expected = registry_signing_key(master_key_bytes).verifying_key();
+
+        match (&self.registry_signature, &self.signer_pubkey) {
+            (None, None) => Ok(RegistryTrust::UnsignedLegacy),
+            (Some(_), None) | (None, Some(_)) => Err(anyhow::anyhow!(
+                "device registry signature envelope is incomplete (signature/signer_pubkey \
+                 mismatch); refusing to trust"
+            )),
+            (Some(sig_b64), Some(signer_b64)) => {
+                // 1. The signer pubkey in the envelope MUST be the master-derived
+                //    one. A signature that verifies against an attacker-chosen key
+                //    is worthless, so bind to the expected signer first.
+                let signer_bytes = b64()
+                    .decode(signer_b64.as_bytes())
+                    .context("decoding registry signer pubkey")?;
+                let signer_arr: [u8; 32] = signer_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("registry signer pubkey is not 32 bytes"))?;
+                if signer_arr != expected.to_bytes() {
+                    return Err(anyhow::anyhow!(
+                        "device registry signed by an UNEXPECTED key (not the master-derived \
+                         signer); refusing to trust — possible tampering or wrong master key"
+                    ));
+                }
+
+                // 2. Verify the signature over the canonical payload.
+                let sig_bytes = b64()
+                    .decode(sig_b64.as_bytes())
+                    .context("decoding registry signature")?;
+                let sig_arr: [u8; 64] = sig_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("registry signature is not 64 bytes"))?;
+                let signature = Signature::from_bytes(&sig_arr);
+                let payload = self.canonical_signing_payload()?;
+                expected.verify(&payload, &signature).map_err(|_| {
+                    anyhow::anyhow!(
+                        "device registry signature FAILED verification; the device list was \
+                         tampered with or re-signed by a different key"
+                    )
+                })?;
+                Ok(RegistryTrust::Signed)
+            }
+        }
+    }
+
+    /// True when the registry carries a signature envelope (signed or tampered),
+    /// as opposed to an unsigned legacy registry.
+    pub fn is_signed(&self) -> bool {
+        self.registry_signature.is_some() || self.signer_pubkey.is_some()
     }
 
     /// Roll-call probe for the per-device wrapping CONTRACT (TIN-1417).
@@ -144,10 +406,19 @@ impl DeviceRegistry {
         }
     }
 
-    /// Revoke a device by name
+    /// Revoke a device by name.
+    ///
+    /// Sets `revoked = true` and stamps `revoked_at` (TIN-1417 B4) so the signed
+    /// envelope records *when* the device lost trust. Callers must re-`sign` and
+    /// persist the registry afterwards; the whole-registry signature plus
+    /// `revoked_at` is the SEV-1 fix (a full append-only signed-event log is a
+    /// follow-up).
     pub fn revoke(&mut self, name: &str) -> bool {
         if let Some(device) = self.devices.iter_mut().find(|d| d.name == name) {
             device.revoked = true;
+            if device.revoked_at.is_none() {
+                device.revoked_at = Some(now_unix());
+            }
             true
         } else {
             false
@@ -184,10 +455,7 @@ impl DeviceRegistry {
     /// Enroll a new device: generates a UUID, creates identity, adds to registry.
     pub fn enroll(&mut self, name: &str, public_key: &str, description: Option<String>) -> String {
         let device_id = uuid::Uuid::new_v4().to_string();
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+        let now = now_unix();
 
         let signing_hash = blake3::hash(public_key.as_bytes()).to_hex().as_str()[..16].to_string();
 
@@ -199,6 +467,9 @@ impl DeviceRegistry {
             description,
             enrolled_at: now,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
@@ -220,7 +491,9 @@ impl DeviceRegistry {
         (device_id, key)
     }
 
-    /// Load device registry from S3 remote storage.
+    /// Load device registry from S3 remote storage (no signature verification).
+    ///
+    /// Security-sensitive callers must use [`DeviceRegistry::load_remote_verified`].
     pub async fn load_remote(op: &opendal::Operator, meta_prefix: &str) -> Result<Self> {
         let key = format!(
             "{}/tcfs-meta/devices.json",
@@ -238,7 +511,37 @@ impl DeviceRegistry {
         }
     }
 
-    /// Sync (upload) device registry to S3 remote storage.
+    /// Load the remote registry AND verify its signature (TIN-1417 B4).
+    ///
+    /// The remote object store is the primary tamper surface: anyone with direct
+    /// write access to `meta_prefix/tcfs-meta/devices.json` could inject a hostile
+    /// recipient. A present-but-invalid signature is a HARD error; an unsigned
+    /// remote registry returns [`RegistryTrust::UnsignedLegacy`] with a warning.
+    pub async fn load_remote_verified(
+        op: &opendal::Operator,
+        meta_prefix: &str,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<(Self, RegistryTrust)> {
+        let reg = Self::load_remote(op, meta_prefix).await?;
+        if reg.devices.is_empty() && !reg.is_signed() {
+            // Nothing was stored yet (NotFound -> default); treat as trusted-empty.
+            return Ok((reg, RegistryTrust::Signed));
+        }
+        let trust = reg
+            .verify_signature(master_key_bytes)
+            .context("verifying remote device registry signature")?;
+        if trust == RegistryTrust::UnsignedLegacy {
+            tracing::warn!(
+                "remote device registry is UNSIGNED (legacy). Accepting inside the TIN-1417 B4 \
+                 migration window; its recipient set is UNVERIFIED."
+            );
+        }
+        Ok((reg, trust))
+    }
+
+    /// Sync (upload) device registry to S3 remote storage (writes current envelope).
+    ///
+    /// Prefer [`DeviceRegistry::sync_to_remote_signed`] which re-signs first.
     pub async fn sync_to_remote(&self, op: &opendal::Operator, meta_prefix: &str) -> Result<()> {
         let key = format!(
             "{}/tcfs-meta/devices.json",
@@ -249,6 +552,17 @@ impl DeviceRegistry {
             .await
             .map_err(|e| anyhow::anyhow!("writing remote device registry: {e}"))?;
         Ok(())
+    }
+
+    /// Sign with the master-derived key, then upload to S3 (TIN-1417 B4).
+    pub async fn sync_to_remote_signed(
+        &mut self,
+        op: &opendal::Operator,
+        meta_prefix: &str,
+        master_key_bytes: &[u8; 32],
+    ) -> Result<()> {
+        self.sign(master_key_bytes)?;
+        self.sync_to_remote(op, meta_prefix).await
     }
 
     /// Enroll a device with a real age X25519 keypair and sync to remote S3.
@@ -328,6 +642,14 @@ pub fn is_real_age_public_key(public_key: &str) -> bool {
     public_key.parse::<age::x25519::Recipient>().is_ok()
 }
 
+/// Current Unix time in seconds (saturating to 0 before the epoch).
+fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 /// Get the default device registry path
 pub fn default_registry_path() -> PathBuf {
     let config_dir = dirs_path();
@@ -369,6 +691,9 @@ mod tests {
             description: None,
             enrolled_at: 1000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
@@ -388,11 +713,16 @@ mod tests {
             description: None,
             enrolled_at: 1000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 0,
         });
 
         assert!(reg.revoke("old-phone"));
         assert_eq!(reg.active_devices().count(), 0);
+        // revoke() stamps revoked_at (TIN-1417 B4).
+        assert!(reg.find("old-phone").unwrap().revoked_at.is_some());
         assert!(!reg.revoke("nonexistent"));
     }
 
@@ -410,6 +740,9 @@ mod tests {
             description: Some("my test device".into()),
             enrolled_at: 2000,
             revoked: false,
+            revoked_at: None,
+            enrolled_by: None,
+            signing_pubkey: None,
             last_nats_seq: 42,
         });
         reg.save(&path).unwrap();
@@ -543,5 +876,246 @@ mod tests {
             !rc.all_capable(),
             "an empty active set must not satisfy the contract gate"
         );
+    }
+
+    // ── TIN-1417 B4: signed registry ──────────────────────────────────────────
+
+    const MASTER_A: [u8; 32] = [0x11; 32];
+    const MASTER_B: [u8; 32] = [0x22; 32];
+
+    fn signed_registry(master: &[u8; 32]) -> DeviceRegistry {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("alpha", &real_pubkey(), None);
+        reg.enroll("beta", &real_pubkey(), None);
+        reg.sign(master).unwrap();
+        reg
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let reg = signed_registry(&MASTER_A);
+        assert!(reg.is_signed());
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::Signed
+        );
+    }
+
+    #[test]
+    fn signing_is_deterministic_for_same_device_set() {
+        let mut a = DeviceRegistry::default();
+        let pk1 = real_pubkey();
+        let pk2 = real_pubkey();
+        a.enroll("one", &pk1, None);
+        a.enroll("two", &pk2, None);
+        // Same devices (same ids/keys) inserted in the OPPOSITE order.
+        let mut b = DeviceRegistry {
+            devices: a.devices.iter().cloned().rev().collect(),
+            ..Default::default()
+        };
+        a.sign(&MASTER_A).unwrap();
+        b.sign(&MASTER_A).unwrap();
+        assert_eq!(
+            a.registry_signature, b.registry_signature,
+            "canonical signing payload must be order-independent"
+        );
+    }
+
+    #[test]
+    fn tamper_inject_recipient_fails_verification() {
+        let mut reg = signed_registry(&MASTER_A);
+        // Attacker appends a hostile recipient but cannot re-sign.
+        reg.enroll("attacker", &real_pubkey(), None);
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("FAILED verification"),
+            "injecting a recipient must fail signature verification: {err:#}"
+        );
+    }
+
+    #[test]
+    fn tamper_unrevoke_fails_verification() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("keep", &real_pubkey(), None);
+        reg.enroll("gone", &real_pubkey(), None);
+        reg.revoke("gone");
+        reg.sign(&MASTER_A).unwrap();
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::Signed
+        );
+        // Attacker un-revokes the device in place.
+        reg.devices
+            .iter_mut()
+            .find(|d| d.name == "gone")
+            .unwrap()
+            .revoked = false;
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("FAILED verification"),
+            "un-revoking a device must fail signature verification: {err:#}"
+        );
+    }
+
+    #[test]
+    fn tamper_flip_field_fails_verification() {
+        let mut reg = signed_registry(&MASTER_A);
+        reg.devices[0].public_key = real_pubkey();
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("FAILED verification"), "{err:#}");
+    }
+
+    #[test]
+    fn signature_from_unrelated_key_is_rejected() {
+        // Registry signed by master B is rejected when verified against master A.
+        let reg = signed_registry(&MASTER_B);
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(
+            err.to_string().contains("UNEXPECTED key"),
+            "a signature from a non-master-derived signer must be rejected: {err:#}"
+        );
+    }
+
+    #[test]
+    fn forged_signer_pubkey_is_rejected() {
+        // Attacker re-signs with their OWN ed25519 key and swaps in their pubkey;
+        // verification must still reject because the signer isn't master-derived.
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("victim", &real_pubkey(), None);
+        let attacker = registry_signing_key(&MASTER_B); // any non-master-A key
+        let payload = reg.canonical_signing_payload().unwrap();
+        let sig: Signature = attacker.sign(&payload);
+        reg.registry_signature = Some(b64().encode(sig.to_bytes()));
+        reg.signer_pubkey = Some(b64().encode(attacker.verifying_key().to_bytes()));
+        reg.sig_alg = Some(REGISTRY_SIG_ALG.to_string());
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("UNEXPECTED key"), "{err:#}");
+    }
+
+    #[test]
+    fn incomplete_envelope_is_rejected() {
+        let mut reg = signed_registry(&MASTER_A);
+        reg.signer_pubkey = None; // signature present but signer missing
+        let err = reg.verify_signature(&MASTER_A).unwrap_err();
+        assert!(err.to_string().contains("incomplete"), "{err:#}");
+    }
+
+    #[test]
+    fn unsigned_legacy_registry_loads_with_migration_trust() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("legacy", &real_pubkey(), None);
+        assert!(!reg.is_signed());
+        assert_eq!(
+            reg.verify_signature(&MASTER_A).unwrap(),
+            RegistryTrust::UnsignedLegacy
+        );
+    }
+
+    #[test]
+    fn legacy_json_without_new_fields_still_parses() {
+        // A registry as written by the pre-B4 code: no envelope, no new fields.
+        let legacy = r#"{
+            "devices": [
+                {
+                    "name": "old",
+                    "device_id": "id-1",
+                    "public_key": "age1legacy",
+                    "enrolled_at": 100,
+                    "revoked": false
+                }
+            ]
+        }"#;
+        let reg: DeviceRegistry = serde_json::from_str(legacy).unwrap();
+        assert_eq!(reg.devices.len(), 1);
+        assert_eq!(reg.devices[0].revoked_at, None);
+        assert_eq!(reg.devices[0].enrolled_by, None);
+        assert!(!reg.is_signed());
+    }
+
+    #[test]
+    fn save_signed_then_load_verified_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("devices.json");
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("disk", &real_pubkey(), None);
+        reg.save_signed(&path, &MASTER_A).unwrap();
+
+        let (loaded, trust) = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap();
+        assert_eq!(trust, RegistryTrust::Signed);
+        assert_eq!(loaded.devices.len(), 1);
+
+        // A registry signed by a different master fails load_verified.
+        let err = DeviceRegistry::load_verified(&path, &MASTER_B).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("UNEXPECTED key"),
+            "load_verified must reject a registry signed by a different master: {err:#}"
+        );
+    }
+
+    #[test]
+    fn load_verified_missing_file_is_trusted_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.json");
+        let (reg, trust) = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap();
+        assert!(reg.devices.is_empty());
+        assert_eq!(trust, RegistryTrust::Signed);
+    }
+
+    #[test]
+    fn tampered_on_disk_json_fails_load_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("devices.json");
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("orig", &real_pubkey(), None);
+        reg.save_signed(&path, &MASTER_A).unwrap();
+
+        // Tamper with the JSON on disk: inject a hostile recipient by hand.
+        let mut value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let devices = value["devices"].as_array_mut().unwrap();
+        devices.push(serde_json::json!({
+            "name": "evil",
+            "device_id": "evil-id",
+            "public_key": real_pubkey(),
+            "enrolled_at": 1,
+            "revoked": false
+        }));
+        std::fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+        let err = DeviceRegistry::load_verified(&path, &MASTER_A).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("verifying device registry signature")
+                || err.to_string().contains("FAILED verification"),
+            "a hand-tampered on-disk registry must fail load_verified: {err:#}"
+        );
+    }
+
+    #[test]
+    fn unsigned_registry_serializes_without_new_envelope_or_identity_fields() {
+        // Back-compat: an UNSIGNED registry must serialize byte-compatibly with
+        // the pre-B4 schema — none of the new optional fields leak into the JSON,
+        // so older readers see exactly what they used to.
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("plain", &real_pubkey(), None);
+        let json = serde_json::to_string(&reg).unwrap();
+        for forbidden in [
+            "registry_signature",
+            "signer_pubkey",
+            "sig_alg",
+            "revoked_at",
+            "enrolled_by",
+            "signing_pubkey",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "unsigned registry must not emit `{forbidden}` (back-compat): {json}"
+            );
+        }
+        // A signed registry, by contrast, DOES carry the envelope fields.
+        reg.sign(&MASTER_A).unwrap();
+        let signed = serde_json::to_string(&reg).unwrap();
+        assert!(signed.contains("registry_signature"));
+        assert!(signed.contains("signer_pubkey"));
     }
 }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -34,6 +34,29 @@ pub struct DeviceIdentity {
     pub last_nats_seq: u64,
 }
 
+/// Result of a per-device roll-call probe (TIN-1417).
+///
+/// See [`DeviceRegistry::roll_call`]. The CONTRACT (`PerDevice`) wrap mode is
+/// only safe to enter when `all_capable()` is true.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollCall {
+    /// Number of active (non-revoked) devices.
+    pub active: usize,
+    /// Number of active devices that carry a real age recipient.
+    pub capable: usize,
+    /// Names of active devices that lack a real age recipient (the blockers).
+    pub incapable_devices: Vec<String>,
+}
+
+impl RollCall {
+    /// True when at least one active device exists and EVERY active device is
+    /// per-device-capable (has a real age recipient). Only then is it safe to
+    /// drop the shared master wrap.
+    pub fn all_capable(&self) -> bool {
+        self.active > 0 && self.capable == self.active && self.incapable_devices.is_empty()
+    }
+}
+
 /// Device registry: tracks all enrolled devices for this user
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DeviceRegistry {
@@ -89,6 +112,36 @@ impl DeviceRegistry {
     /// List active (non-revoked) devices
     pub fn active_devices(&self) -> impl Iterator<Item = &DeviceIdentity> {
         self.devices.iter().filter(|d| !d.revoked)
+    }
+
+    /// Roll-call probe for the per-device wrapping CONTRACT (TIN-1417).
+    ///
+    /// Inspects every active (non-revoked) device and reports whether each one
+    /// carries a *real* age recipient. The daemon must NOT drop the shared
+    /// master wrap (i.e. enter [`crate`]'s `PerDevice` contract mode) unless this
+    /// returns [`RollCall::all_capable`] true — otherwise a device that lacks a
+    /// real age recipient would be locked out of newly written content.
+    ///
+    /// When the roll call is not satisfied callers fall back to dual-wrapping
+    /// (master + per-device) and log the offending devices, never silently
+    /// dropping the master fallback.
+    pub fn roll_call(&self) -> RollCall {
+        let mut active = 0usize;
+        let mut capable = 0usize;
+        let mut incapable_devices = Vec::new();
+        for d in self.active_devices() {
+            active += 1;
+            if is_real_age_public_key(&d.public_key) {
+                capable += 1;
+            } else {
+                incapable_devices.push(d.name.clone());
+            }
+        }
+        RollCall {
+            active,
+            capable,
+            incapable_devices,
+        }
     }
 
     /// Revoke a device by name
@@ -428,5 +481,67 @@ mod tests {
         let id = reg.enroll("xoxd-bates", "age1xoxd", Some("main server".into()));
         assert!(reg.find_by_id(&id).is_some());
         assert!(reg.find_by_id("nonexistent-uuid").is_none());
+    }
+
+    // ── TIN-1417: roll-call gate for the per-device CONTRACT ───────────────
+
+    fn real_pubkey() -> String {
+        generate_local_device_key().public_key
+    }
+
+    #[test]
+    fn roll_call_all_capable_when_every_active_device_has_real_recipient() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("a", &real_pubkey(), None);
+        reg.enroll("b", &real_pubkey(), None);
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 2);
+        assert_eq!(rc.capable, 2);
+        assert!(rc.incapable_devices.is_empty());
+        assert!(
+            rc.all_capable(),
+            "all active devices are per-device-capable"
+        );
+    }
+
+    #[test]
+    fn roll_call_blocks_when_any_active_device_lacks_real_recipient() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("real", &real_pubkey(), None);
+        // Placeholder / non-age public key: not a real recipient.
+        reg.enroll("placeholder", "age1xoxd-not-a-real-key", None);
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 2);
+        assert_eq!(rc.capable, 1);
+        assert_eq!(rc.incapable_devices, vec!["placeholder".to_string()]);
+        assert!(
+            !rc.all_capable(),
+            "must block PerDevice while any active device cannot do per-device unwrap"
+        );
+    }
+
+    #[test]
+    fn roll_call_revoked_devices_do_not_block() {
+        let mut reg = DeviceRegistry::default();
+        reg.enroll("real", &real_pubkey(), None);
+        reg.enroll("old-placeholder", "age1xoxd-not-a-real-key", None);
+        assert!(reg.revoke("old-placeholder"));
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 1);
+        assert!(
+            rc.all_capable(),
+            "a revoked non-capable device must not block the roll call"
+        );
+    }
+
+    #[test]
+    fn roll_call_empty_registry_is_not_capable() {
+        let reg = DeviceRegistry::default();
+        let rc = reg.roll_call();
+        assert_eq!(rc.active, 0);
+        assert!(
+            !rc.all_capable(),
+            "an empty active set must not satisfy the contract gate"
+        );
     }
 }

--- a/crates/tcfs-secrets/src/device.rs
+++ b/crates/tcfs-secrets/src/device.rs
@@ -26,7 +26,7 @@
 
 use anyhow::{Context, Result};
 use base64::Engine as _;
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -144,8 +144,15 @@ pub struct DeviceRegistry {
 pub enum RegistryTrust {
     /// Envelope carried a valid signature from the expected master-derived signer.
     Signed,
-    /// Legacy registry with no signature. Accepted only inside the migration
-    /// window; callers must treat its recipient set as UNVERIFIED.
+    /// Legacy registry with no signature. Accepted only inside the bounded
+    /// TIN-1417 B4 migration window; callers MUST treat its recipient set as
+    /// UNVERIFIED and MUST NOT launder it into a signed registry (see
+    /// `enforce_remote_merge_trust` on the enroll `--sync-remote` path).
+    ///
+    /// MIGRATION WINDOW (TODO TIN-1417 B5, hard-reject by 2026-09-01): once every
+    /// fleet has re-saved at least once with a master key, the read-side builders
+    /// and the remote-merge path should reject `UnsignedLegacy` outright instead
+    /// of falling back to the master wrap / requiring an opt-in flag.
     UnsignedLegacy,
 }
 
@@ -359,7 +366,10 @@ impl DeviceRegistry {
                     .map_err(|_| anyhow::anyhow!("registry signature is not 64 bytes"))?;
                 let signature = Signature::from_bytes(&sig_arr);
                 let payload = self.canonical_signing_payload()?;
-                expected.verify(&payload, &signature).map_err(|_| {
+                // verify_strict (not verify): rejects non-canonical / small-order
+                // signature components, closing Ed25519 malleability so a tampered
+                // registry cannot ride along on a malleable-but-valid signature.
+                expected.verify_strict(&payload, &signature).map_err(|_| {
                     anyhow::anyhow!(
                         "device registry signature FAILED verification; the device list was \
                          tampered with or re-signed by a different key"

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -982,17 +982,30 @@ where
 /// When present, chunks are encrypted before upload and decrypted after download
 /// using XChaCha20-Poly1305 with per-file keys wrapped by the master key.
 #[cfg(feature = "crypto")]
+pub use tcfs_core::config::WrapMode;
+
+#[cfg(feature = "crypto")]
 pub struct EncryptionContext {
     pub master_key: tcfs_crypto::MasterKey,
+    /// File-key wrap mode (TIN-1417). Drives the write path:
+    /// - [`WrapMode::Master`]: master-only wrap (`encrypted_file_key`), manifest v2.
+    /// - [`WrapMode::Dual`]: BOTH master wrap + per-device wraps, manifest v2.
+    /// - [`WrapMode::PerDevice`]: per-device wraps ONLY (drops master wrap),
+    ///   manifest **v3**.
+    ///
+    /// Callers MUST satisfy the roll-call gate before selecting `PerDevice`
+    /// (see `with_wrap_mode` / the daemon's `build_encryption_context`). When the
+    /// gate is not satisfied callers fall back to `Dual` and warn — the engine
+    /// itself trusts the mode it is handed.
+    pub wrap_mode: WrapMode,
     /// Active-device recipients for per-device FileKey wrapping (TIN-1417).
     ///
-    /// When non-empty, writes emit per-device `wrapped_file_keys` and OMIT the
-    /// master-wrapped `encrypted_file_key`, so a device removed from this set
-    /// (revoked) cannot decrypt newly written content. Empty = legacy
-    /// shared-master behavior.
+    /// Required (non-empty) for `Dual` and `PerDevice`; ignored for `Master`.
+    /// A device removed from this set (revoked) cannot decrypt content written
+    /// after its removal in `PerDevice` mode.
     pub device_recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
     /// This device's age identity, used to unwrap per-device manifests on read.
-    /// `None` relies on the master-key fallback (legacy manifests).
+    /// `None` relies on the master-key fallback (legacy / master / dual manifests).
     pub device_identity: Option<DeviceUnwrapIdentity>,
 }
 
@@ -1008,21 +1021,47 @@ pub struct DeviceUnwrapIdentity {
 
 #[cfg(feature = "crypto")]
 impl EncryptionContext {
-    /// Legacy shared-master context: no per-device recipients or identity.
+    /// Legacy shared-master context: master-only wrap, no per-device recipients
+    /// or identity. [`WrapMode::Master`] — byte-identical to the historical
+    /// default.
     pub fn new(master_key: tcfs_crypto::MasterKey) -> Self {
         Self {
             master_key,
+            wrap_mode: WrapMode::Master,
             device_recipients: Vec::new(),
             device_identity: None,
         }
     }
 
-    /// Attach per-device wrapping recipients and this device's unwrap identity.
+    /// Attach per-device wrapping recipients and this device's unwrap identity,
+    /// selecting [`WrapMode::PerDevice`] (per-device-only, manifest v3).
+    ///
+    /// Prefer [`Self::with_wrap_mode`] when the caller needs `Dual`. This method
+    /// preserves the pre-TIN-1417-enum behavior (recipients present =>
+    /// per-device-only writes) for existing call sites and tests. Callers MUST
+    /// have satisfied the roll-call gate before reaching `PerDevice`.
     pub fn with_device_wrapping(
-        mut self,
+        self,
         recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
         identity: Option<DeviceUnwrapIdentity>,
     ) -> Self {
+        self.with_wrap_mode(WrapMode::PerDevice, recipients, identity)
+    }
+
+    /// Attach an explicit wrap mode plus the per-device recipient set and this
+    /// device's unwrap identity.
+    ///
+    /// For [`WrapMode::Master`] the recipients/identity are still recorded (so
+    /// the same context can read per-device manifests it encounters) but the
+    /// write path emits the master-only wrap. For `Dual`/`PerDevice` the
+    /// recipients drive the per-device wraps.
+    pub fn with_wrap_mode(
+        mut self,
+        wrap_mode: WrapMode,
+        recipients: Vec<tcfs_crypto::AgeFileKeyRecipient>,
+        identity: Option<DeviceUnwrapIdentity>,
+    ) -> Self {
+        self.wrap_mode = wrap_mode;
         self.device_recipients = recipients;
         self.device_identity = identity;
         self
@@ -1849,22 +1888,27 @@ async fn upload_file_with_device_with_state(
 
     ensure_source_matches_snapshot(local_path, &snapshot, "manifest publish")?;
 
-    // Wrap the file key for the manifest. With per-device recipients (TIN-1417)
-    // we emit only per-device `wrapped_file_keys` and OMIT the master-wrapped
-    // `encrypted_file_key`, so a revoked device (absent from the recipient set)
-    // cannot decrypt new content. Without recipients we keep the legacy
-    // shared-master wrap for backward compatibility.
+    // Wrap the file key for the manifest, branching on the wrap mode (TIN-1417):
+    //
+    // - `Master`  : master-only wrap (`encrypted_file_key`). Byte-identical to
+    //               the legacy default. Manifest stays version 2.
+    // - `Dual`    : EXPAND/transitional. Emit BOTH the master wrap (rollback +
+    //               master/old-binary readers) AND per-device wraps. Version 2
+    //               (back-compatible by construction).
+    // - `PerDevice`: CONTRACT. Emit ONLY per-device wraps and DROP the master
+    //               wrap (true revocation). Bumps the manifest to version 3 so
+    //               pre-per-device binaries fail CLOSED.
+    //
+    // The roll-call gate (daemon/CLI/FP `build_encryption_context`) guarantees
+    // `PerDevice`/`Dual` are only handed here with a real recipient set; we
+    // still fail CLOSED below if `Dual`/`PerDevice` arrives with no recipients
+    // rather than silently writing an unreadable or master-only manifest.
     #[cfg(feature = "crypto")]
-    let (encrypted_file_key, wrapped_file_keys) = if let (Some(ctx), Some(ref fk)) =
-        (encryption, &file_key)
-    {
-        if ctx.device_recipients.is_empty() {
-            let wrapped =
-                tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
-            let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &wrapped);
-            (Some(b64), Vec::new())
-        } else {
-            let wrapped = tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
+    let wrap_age_recipients = |ctx: &EncryptionContext,
+                               fk: &tcfs_crypto::FileKey|
+     -> Result<Vec<crate::manifest::WrappedFileKey>> {
+        Ok(
+            tcfs_crypto::wrap_file_key_for_age_recipients(fk, &ctx.device_recipients)
                 .context("wrapping file key for device recipients")?
                 .into_iter()
                 .map(|w| crate::manifest::WrappedFileKey {
@@ -1873,17 +1917,54 @@ async fn upload_file_with_device_with_state(
                     algorithm: w.algorithm,
                     wrapped_key: w.wrapped_key,
                 })
-                .collect();
-            (None, wrapped)
-        }
-    } else {
-        (None, Vec::new())
+                .collect(),
+        )
     };
+
+    #[cfg(feature = "crypto")]
+    let (encrypted_file_key, wrapped_file_keys, manifest_version) =
+        if let (Some(ctx), Some(ref fk)) = (encryption, &file_key) {
+            let master_wrap = |fk: &tcfs_crypto::FileKey| -> Result<String> {
+                let wrapped =
+                    tcfs_crypto::wrap_key(&ctx.master_key, fk).context("wrapping file key")?;
+                Ok(base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &wrapped,
+                ))
+            };
+            match ctx.wrap_mode {
+                WrapMode::Master => (Some(master_wrap(fk)?), Vec::new(), 2u32),
+                WrapMode::Dual => {
+                    if ctx.device_recipients.is_empty() {
+                        anyhow::bail!(
+                        "wrap_mode=Dual requires per-device recipients but none are configured; \
+                             refusing to write (would silently degrade to master-only)"
+                    );
+                    }
+                    (Some(master_wrap(fk)?), wrap_age_recipients(ctx, fk)?, 2u32)
+                }
+                WrapMode::PerDevice => {
+                    if ctx.device_recipients.is_empty() {
+                        // Fail CLOSED: a PerDevice write with no recipients would
+                        // produce a keyless v3 manifest that nobody can read.
+                        anyhow::bail!(
+                            "wrap_mode=PerDevice requires per-device recipients but none are \
+                             configured; refusing to drop the master wrap (fail-closed)"
+                        );
+                    }
+                    (None, wrap_age_recipients(ctx, fk)?, 3u32)
+                }
+            }
+        } else {
+            (None, Vec::new(), 2u32)
+        };
 
     #[cfg(not(feature = "crypto"))]
     let encrypted_file_key: Option<String> = None;
     #[cfg(not(feature = "crypto"))]
     let wrapped_file_keys: Vec<crate::manifest::WrappedFileKey> = Vec::new();
+    #[cfg(not(feature = "crypto"))]
+    let manifest_version: u32 = 2;
 
     // Capture Unix file permissions for cross-device preservation
     #[cfg(unix)]
@@ -1896,14 +1977,16 @@ async fn upload_file_with_device_with_state(
     #[cfg(not(unix))]
     let file_mode: Option<u32> = None;
 
-    // Build and upload SyncManifest v2
+    // Build and upload the manifest. Version is 2 for Master/Dual and 3 for
+    // PerDevice (see the wrap-mode branch above) so pre-per-device binaries fail
+    // CLOSED on a master-wrap-less v3 manifest instead of misreading it.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
 
     let manifest = SyncManifest {
-        version: 2,
+        version: manifest_version,
         file_hash: file_hash_hex.clone(),
         file_size,
         chunks: chunk_hashes,
@@ -2180,6 +2263,40 @@ pub async fn download_file_with_device(
 
     let manifest = SyncManifest::from_bytes(&manifest_bytes)
         .with_context(|| format!("parsing manifest: {remote_manifest}"))?;
+
+    // Manifest version gate (TIN-1417). v1 (legacy text) and v2 (master/dual)
+    // are always readable. v3 is the per-device-only (CONTRACT) shape that DROPS
+    // the master wrap; a binary without per-device read support MUST fail CLOSED
+    // rather than misread a master-wrap-less manifest as keyless. Any version
+    // beyond what we understand is also rejected.
+    //
+    // With the `crypto` feature, v3 is supported; the per-device unwrap branch
+    // below independently fails CLOSED when no device identity is available. The
+    // `wrapped_file_keys` shape check guards against a v3 claim with no per-device
+    // wraps (which we could not decrypt). Without `crypto`, v3 is never readable.
+    #[cfg(feature = "crypto")]
+    {
+        if manifest.version > 3 {
+            anyhow::bail!(
+                "manifest version {} is newer than this binary supports (max 3) for: {remote_manifest}; refusing (fail-closed)",
+                manifest.version
+            );
+        }
+        if manifest.version == 3 && manifest.wrapped_file_keys.is_empty() {
+            anyhow::bail!(
+                "manifest claims per-device (v3) but carries no wrapped_file_keys for: {remote_manifest}; refusing (fail-closed)"
+            );
+        }
+    }
+    #[cfg(not(feature = "crypto"))]
+    {
+        if manifest.version >= 3 {
+            anyhow::bail!(
+                "manifest version {} requires per-device crypto support not built into this binary for: {remote_manifest}; refusing (fail-closed)",
+                manifest.version
+            );
+        }
+    }
 
     let chunk_hashes = manifest.chunk_hashes();
 

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2227,7 +2227,7 @@ pub async fn upload_symlink_with_device(
     })
 }
 
-fn read_symlink_target_text(path: &Path) -> Result<String> {
+pub(crate) fn read_symlink_target_text(path: &Path) -> Result<String> {
     let target = std::fs::read_link(path)
         .with_context(|| format!("reading symlink target: {}", path.display()))?;
     target
@@ -2236,7 +2236,12 @@ fn read_symlink_target_text(path: &Path) -> Result<String> {
         .with_context(|| format!("symlink target is not valid UTF-8: {}", path.display()))
 }
 
-fn symlink_manifest_hash(target: &str) -> String {
+/// Stable identity hash for a symlink, keyed only on its target text.
+///
+/// This is the single source of truth shared by the symlink push path
+/// (`upload_symlink_with_device`), the pull path, and the reconcile compare
+/// path so that all three agree on when two symlinks are "the same".
+pub(crate) fn symlink_manifest_hash(target: &str) -> String {
     let mut data = b"tcfs-symlink-v1\0".to_vec();
     data.extend_from_slice(target.as_bytes());
     tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(&data))

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -2368,37 +2368,17 @@ pub async fn download_file_with_device(
     // (TIN-1417): when present, the file key is unwrapped with this device's age
     // identity. Manifests carrying only the legacy master-wrapped key fall back
     // to master-key unwrap.
+    //
+    // Dual manifests (v2) carry BOTH `wrapped_file_keys` AND a master
+    // `encrypted_file_key`. A device that has NO usable per-device wrap (no
+    // encryption context, no age identity, or no stanza addressing it) MUST fall
+    // back to the master wrap when one is present — this is the whole point of
+    // Dual's rollback/recovery rationale, and keeps a Master-mode/no-identity
+    // device able to read peer-written Dual content. PerDevice manifests (v3)
+    // carry NO master wrap (`encrypted_file_key == None`); for those the
+    // per-device path is the only path and we stay strictly fail-closed.
     #[cfg(feature = "crypto")]
-    let file_key = if !manifest.wrapped_file_keys.is_empty() {
-        let ctx = encryption.ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
-            )
-        })?;
-        let identity = ctx.device_identity.as_ref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
-            )
-        })?;
-        let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
-            .wrapped_file_keys
-            .iter()
-            .map(|w| tcfs_crypto::AgeWrappedFileKey {
-                recipient_device_id: w.recipient_device_id.clone(),
-                recipient: w.recipient.clone(),
-                algorithm: w.algorithm.clone(),
-                wrapped_key: w.wrapped_key.clone(),
-            })
-            .collect();
-        Some(
-            tcfs_crypto::unwrap_file_key_with_age_identity(
-                &age_wraps,
-                &identity.secret,
-                Some(&identity.device_id),
-            )
-            .context("unwrapping per-device file key from manifest")?,
-        )
-    } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+    let unwrap_master = |wrapped_b64: &str| -> Result<tcfs_crypto::FileKey> {
         let ctx = encryption.ok_or_else(|| {
             anyhow::anyhow!(
                 "manifest is encrypted but no encryption context provided for: {remote_manifest}"
@@ -2407,10 +2387,64 @@ pub async fn download_file_with_device(
         let wrapped =
             base64::Engine::decode(&base64::engine::general_purpose::STANDARD, wrapped_b64)
                 .context("decoding wrapped file key from manifest")?;
-        Some(
-            tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
-                .context("unwrapping file key from manifest")?,
-        )
+        tcfs_crypto::unwrap_key(&ctx.master_key, &wrapped)
+            .context("unwrapping file key from manifest")
+    };
+
+    #[cfg(feature = "crypto")]
+    let file_key = if !manifest.wrapped_file_keys.is_empty() {
+        // Attempt the per-device unwrap first (preferred). Capture the failure
+        // instead of propagating so we can fall back to the master wrap when the
+        // manifest carries one (Dual/v2).
+        let per_device: Result<tcfs_crypto::FileKey> = (|| {
+            let ctx = encryption.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "manifest is per-device encrypted but no encryption context provided for: {remote_manifest}"
+                )
+            })?;
+            let identity = ctx.device_identity.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "manifest is per-device encrypted but this device has no age identity for: {remote_manifest}"
+                )
+            })?;
+            let age_wraps: Vec<tcfs_crypto::AgeWrappedFileKey> = manifest
+                .wrapped_file_keys
+                .iter()
+                .map(|w| tcfs_crypto::AgeWrappedFileKey {
+                    recipient_device_id: w.recipient_device_id.clone(),
+                    recipient: w.recipient.clone(),
+                    algorithm: w.algorithm.clone(),
+                    wrapped_key: w.wrapped_key.clone(),
+                })
+                .collect();
+            tcfs_crypto::unwrap_file_key_with_age_identity(
+                &age_wraps,
+                &identity.secret,
+                Some(&identity.device_id),
+            )
+            .context("unwrapping per-device file key from manifest")
+        })();
+
+        match per_device {
+            Ok(fk) => Some(fk),
+            Err(per_device_err) => {
+                // Fall back to the master wrap ONLY when one is actually present
+                // (Dual/v2). A v3 (PerDevice) manifest has no master wrap and
+                // MUST stay strictly fail-closed — surface the per-device error.
+                if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+                    debug!(
+                        remote = %remote_manifest,
+                        error = %per_device_err,
+                        "per-device unwrap unavailable; falling back to master wrap (Dual manifest)"
+                    );
+                    Some(unwrap_master(wrapped_b64)?)
+                } else {
+                    return Err(per_device_err);
+                }
+            }
+        }
+    } else if let Some(ref wrapped_b64) = manifest.encrypted_file_key {
+        Some(unwrap_master(wrapped_b64)?)
     } else {
         None
     };

--- a/crates/tcfs-sync/src/engine.rs
+++ b/crates/tcfs-sync/src/engine.rs
@@ -1262,6 +1262,72 @@ fn unique_tmp_path(local_path: &Path, marker: &str) -> PathBuf {
     local_path.with_file_name(file_name)
 }
 
+/// Convert a `SystemTime` into `(unix_secs, subsec_nanos)` for manifest storage.
+///
+/// Times before the Unix epoch are represented with a negative seconds component
+/// and the matching positive sub-second remainder, mirroring `utimensat`'s
+/// `timespec` convention so the round-trip is lossless.
+fn systemtime_to_unix_parts(t: SystemTime) -> (i64, u32) {
+    match t.duration_since(UNIX_EPOCH) {
+        Ok(d) => (d.as_secs() as i64, d.subsec_nanos()),
+        Err(e) => {
+            // Pre-epoch: duration is how far *before* the epoch we are.
+            let d = e.duration();
+            let nanos = d.subsec_nanos();
+            if nanos == 0 {
+                (-(d.as_secs() as i64), 0)
+            } else {
+                // Borrow one second so the nanos component stays in [0, 1e9).
+                (-(d.as_secs() as i64) - 1, 1_000_000_000 - nanos)
+            }
+        }
+    }
+}
+
+/// Apply a previously captured `(unix_secs, subsec_nanos)` mtime to `path`.
+///
+/// Only the modification time is set; the access time is left to the kernel's
+/// default (`UTIME_OMIT`). On non-Unix targets this is a no-op — the manifest
+/// still carries the value, and a future port can honor it. Best-effort: a
+/// failure to restamp is logged but never aborts the restore, since the file
+/// content is already correctly written.
+#[cfg(unix)]
+fn apply_manifest_mtime(path: &Path, mtime: (i64, u32)) {
+    use std::os::unix::ffi::OsStrExt;
+    let (secs, nanos) = mtime;
+    let c_path = match std::ffi::CString::new(path.as_os_str().as_bytes()) {
+        Ok(p) => p,
+        Err(_) => {
+            warn!(path = %path.display(), "skipping mtime restore: path contains NUL");
+            return;
+        }
+    };
+    // mtime carries the captured value; atime is omitted so we don't perturb it.
+    let times = [
+        libc::timespec {
+            tv_sec: 0,
+            tv_nsec: libc::UTIME_OMIT,
+        },
+        libc::timespec {
+            tv_sec: secs as libc::time_t,
+            tv_nsec: nanos as _,
+        },
+    ];
+    // SAFETY: `c_path` is a valid NUL-terminated C string for the duration of
+    // the call, and `times` is a 2-element array of initialized `timespec`.
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c_path.as_ptr(), times.as_ptr(), 0) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        warn!(path = %path.display(), error = %err, "failed to restore mtime from manifest");
+    }
+}
+
+#[cfg(not(unix))]
+fn apply_manifest_mtime(_path: &Path, _mtime: (i64, u32)) {
+    // No portable non-Unix mtime restore is wired yet; the value still round-trips
+    // through the manifest so a future port can honor it.
+}
+
 /// Upload a single file to SeaweedFS, chunking it via FastCDC.
 ///
 /// If the file is unchanged since the last sync (per state cache), the upload
@@ -1966,16 +2032,23 @@ async fn upload_file_with_device_with_state(
     #[cfg(not(feature = "crypto"))]
     let manifest_version: u32 = 2;
 
-    // Capture Unix file permissions for cross-device preservation
+    // Capture Unix file permissions and the source mtime for cross-device
+    // preservation, both from the SAME metadata read so they describe one stat
+    // of the file (no TOCTOU drift between the two). The mtime keeps a restored
+    // tree's timestamps intact so `git status` does not report spurious dirty
+    // (TIN-1620 T13-Z).
+    let source_metadata = std::fs::metadata(local_path).ok();
     #[cfg(unix)]
     let file_mode = {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(local_path)
-            .ok()
-            .map(|m| m.permissions().mode())
+        source_metadata.as_ref().map(|m| m.permissions().mode())
     };
     #[cfg(not(unix))]
     let file_mode: Option<u32> = None;
+    let file_mtime: Option<(i64, u32)> = source_metadata
+        .as_ref()
+        .and_then(|m| m.modified().ok())
+        .map(systemtime_to_unix_parts);
 
     // Build and upload the manifest. Version is 2 for Master/Dual and 3 for
     // PerDevice (see the wrap-mode branch above) so pre-per-device binaries fail
@@ -1995,6 +2068,7 @@ async fn upload_file_with_device_with_state(
         written_at: now,
         rel_path: rel_path.map(|s| s.to_string()),
         mode: file_mode,
+        mtime: file_mtime,
         encrypted_file_key,
         wrapped_file_keys,
     };
@@ -2326,6 +2400,13 @@ pub async fn download_file_with_device(
                 .with_context(|| format!("restoring permissions on: {}", local_path.display()))?;
         }
 
+        // Restore the source mtime (TIN-1620 T13-Z) BEFORE re-stat below, so the
+        // state cache and `git status` see the original timestamp, not "now".
+        // Old manifests carry `mtime: None`, leaving current behavior unchanged.
+        if let Some(mtime) = manifest.mtime {
+            apply_manifest_mtime(local_path, mtime);
+        }
+
         let mut sync_state_for_result = None;
         if !_device_id.is_empty() {
             let mut local_vclock = state
@@ -2552,6 +2633,13 @@ pub async fn download_file_with_device(
         tokio::fs::set_permissions(local_path, perms)
             .await
             .with_context(|| format!("restoring permissions on: {}", local_path.display()))?;
+    }
+
+    // Restore the source mtime (TIN-1620 T13-Z) BEFORE the re-stat below, so the
+    // state cache and `git status` see the original timestamp, not "now". Old
+    // manifests carry `mtime: None`, leaving current behavior unchanged.
+    if let Some(mtime) = manifest.mtime {
+        apply_manifest_mtime(local_path, mtime);
     }
 
     let mut sync_state_for_result = None;
@@ -4574,6 +4662,192 @@ mod tests {
         assert_eq!(content, "hello world");
     }
 
+    #[test]
+    fn systemtime_to_unix_parts_roundtrips_post_epoch() {
+        // A representative post-epoch instant with sub-second precision.
+        let t = UNIX_EPOCH + Duration::new(1_700_000_000, 123_456_789);
+        assert_eq!(systemtime_to_unix_parts(t), (1_700_000_000, 123_456_789));
+    }
+
+    #[test]
+    fn systemtime_to_unix_parts_handles_pre_epoch() {
+        // 0.5s before the epoch: seconds borrow down, nanos stay in [0, 1e9).
+        let t = UNIX_EPOCH - Duration::new(0, 500_000_000);
+        let (secs, nanos) = systemtime_to_unix_parts(t);
+        assert_eq!(secs, -1);
+        assert_eq!(nanos, 500_000_000);
+    }
+
+    #[cfg(unix)]
+    fn mtime_of(path: &Path) -> (i64, u32) {
+        let meta = std::fs::metadata(path).unwrap();
+        systemtime_to_unix_parts(meta.modified().unwrap())
+    }
+
+    /// (a) Chunked-file path: a file uploaded with a known source mtime restores
+    /// into a fresh dir with that exact mtime, not "now". This is the input to a
+    /// clean `git status` (TIN-1620 T13-Z).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mtime_round_trips_for_chunked_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let state_path = dir.path().join("state.json");
+        let mut state = StateCache::open(&state_path).unwrap();
+
+        let local = dir.path().join("src.txt");
+        // Larger than a chunk boundary is unnecessary; non-empty exercises the
+        // chunked restore path (empty is handled by a separate test).
+        std::fs::write(&local, b"content with a known timestamp").unwrap();
+
+        // Stamp a known, distinctly-old mtime on the source.
+        let known = (1_600_000_000_i64, 250_000_000_u32);
+        apply_manifest_mtime(&local, known);
+        assert_eq!(mtime_of(&local), known, "test setup: source mtime not set");
+
+        let up = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("src.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Restore into a fresh location (no pre-existing file => fresh mtime risk).
+        let restore_dir = tempfile::tempdir().unwrap();
+        let dl_path = restore_dir.path().join("restored.txt");
+        let mut restore_state = StateCache::open(&restore_dir.path().join("s2.json")).unwrap();
+        download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dl_path,
+            "data",
+            None,
+            "device-2",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(&dl_path).unwrap(),
+            b"content with a known timestamp"
+        );
+        let restored = mtime_of(&dl_path);
+        // Seconds must match exactly; nanos within filesystem precision (1us).
+        assert_eq!(restored.0, known.0, "restored mtime seconds drifted");
+        assert!(
+            (restored.1 as i64 - known.1 as i64).abs() <= 1_000,
+            "restored mtime nanos drifted: got {} want {}",
+            restored.1,
+            known.1
+        );
+    }
+
+    /// (a) Empty-file path: the zero-byte restore branch also restamps mtime.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mtime_round_trips_for_empty_file() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let mut state = StateCache::open(&dir.path().join("state.json")).unwrap();
+
+        let local = dir.path().join("empty.txt");
+        std::fs::write(&local, b"").unwrap();
+        let known = (1_555_000_000_i64, 0_u32);
+        apply_manifest_mtime(&local, known);
+
+        let up = upload_file_with_device(
+            &op,
+            &local,
+            "data",
+            &mut state,
+            None,
+            "device-1",
+            Some("empty.txt"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(up.chunks, 0, "empty file must take the chunkless path");
+
+        let restore_dir = tempfile::tempdir().unwrap();
+        let dl_path = restore_dir.path().join("restored_empty.txt");
+        let mut restore_state = StateCache::open(&restore_dir.path().join("s2.json")).unwrap();
+        download_file_with_device(
+            &op,
+            &up.remote_path,
+            &dl_path,
+            "data",
+            None,
+            "device-2",
+            Some(&mut restore_state),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::metadata(&dl_path).unwrap().len(), 0);
+        assert_eq!(
+            mtime_of(&dl_path).0,
+            known.0,
+            "empty-file mtime not restored"
+        );
+    }
+
+    /// (b) Back-compat: a manifest serialized WITHOUT an mtime field (old fleet)
+    /// deserializes to `mtime: None` and restores with today's behavior — no
+    /// panic, no addressing change, mtime left to "now".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn old_manifest_without_mtime_restores_with_current_behavior() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+
+        // A pre-mtime v2 manifest: note no `mtime` key at all.
+        let body = b"legacy body bytes";
+        let file_hash = tcfs_chunks::hash_to_hex(&tcfs_chunks::hash_bytes(body));
+        let chunk_hash = file_hash.clone();
+        op.write(&format!("data/chunks/{chunk_hash}"), body.to_vec())
+            .await
+            .unwrap();
+        let legacy_json = format!(
+            r#"{{"version":2,"file_hash":"{file_hash}","file_size":{},"chunks":["{chunk_hash}"],"vclock":{{"clocks":{{}}}},"written_by":"old","written_at":1,"rel_path":"legacy.txt"}}"#,
+            body.len()
+        );
+        // Sanity: this JSON deserializes with mtime None and never panics.
+        let parsed = SyncManifest::from_bytes(legacy_json.as_bytes()).unwrap();
+        assert!(parsed.mtime.is_none(), "old manifest must yield mtime None");
+
+        let manifest_path = format!("data/manifests/{file_hash}");
+        op.write(&manifest_path, legacy_json.into_bytes())
+            .await
+            .unwrap();
+
+        let dl_path = dir.path().join("legacy_restored.txt");
+        let before = SystemTime::now();
+        let dl = download_file(&op, &manifest_path, &dl_path, "data", None)
+            .await
+            .unwrap();
+        assert_eq!(dl.bytes, body.len() as u64);
+        assert_eq!(std::fs::read(&dl_path).unwrap(), body);
+
+        // Current behavior: mtime is whatever the OS stamped at write (~now), not
+        // some restored value — we never errored and never set an old time.
+        let restored_secs = mtime_of(&dl_path).0;
+        let before_secs = systemtime_to_unix_parts(before).0;
+        assert!(
+            restored_secs + 5 >= before_secs,
+            "restore with no manifest mtime must keep fresh-write timestamp"
+        );
+    }
+
     #[tokio::test]
     async fn download_file_cleans_streaming_tmp_after_chunk_failure() {
         let op = memory_op();
@@ -4602,6 +4876,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("large.bin".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfs-sync/src/manifest.rs
+++ b/crates/tcfs-sync/src/manifest.rs
@@ -47,6 +47,19 @@ pub struct SyncManifest {
     /// Backward-compatible: old manifests deserialize with `mode: None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<u32>,
+    /// Source modification time as `(unix_secs, subsec_nanos)`, preserved across
+    /// sync so a restored tree keeps its original mtimes (TIN-1620 T13-Z).
+    ///
+    /// Without this, a fresh restore stamps "now" onto every file, which smudges
+    /// `.git/index`'s stat cache and makes `git status` report spurious dirty.
+    ///
+    /// Backward-compatible: old manifests deserialize with `mtime: None`, in
+    /// which case restore leaves the current behavior unchanged. This field is
+    /// purely metadata — manifests are content-addressed by the file's BLAKE3
+    /// hash (`manifests/{file_hash}`), so adding it never changes manifest
+    /// identity, dedup, or chunk addressing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtime: Option<(i64, u32)>,
     /// Base64-encoded wrapped file key (present only when E2E encryption is enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_file_key: Option<String>,
@@ -153,6 +166,7 @@ impl SyncManifest {
             written_at: 0,
             rel_path: None,
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         })
@@ -193,6 +207,7 @@ mod tests {
             written_at: 1000,
             rel_path: Some("docs/readme.md".into()),
             mode: Some(0o644),
+            mtime: Some((1_700_000_000, 123_456_789)),
             encrypted_file_key: None,
             wrapped_file_keys: vec![WrappedFileKey {
                 recipient_device_id: "device-a".into(),
@@ -229,6 +244,39 @@ mod tests {
     fn test_empty_manifest_fails() {
         let result = SyncManifest::from_bytes(b"");
         assert!(result.is_err());
+    }
+
+    /// (b) Back-compat: an `mtime: None` manifest must serialize byte-identically
+    /// to one written before the field existed (the key is omitted), so adding
+    /// the field never perturbs manifest identity/addressing for the existing
+    /// fleet. And a JSON blob with no `mtime` key must deserialize to None.
+    #[test]
+    fn mtime_none_is_omitted_and_back_compatible() {
+        let manifest = SyncManifest {
+            version: 2,
+            file_hash: "deadbeef".into(),
+            file_size: 3,
+            chunks: vec!["c0".into()],
+            vclock: VectorClock::new(),
+            written_by: "neo".into(),
+            written_at: 7,
+            rel_path: Some("a.txt".into()),
+            mode: Some(0o644),
+            mtime: None,
+            encrypted_file_key: None,
+            wrapped_file_keys: Vec::new(),
+        };
+        let json = String::from_utf8(manifest.to_bytes().unwrap()).unwrap();
+        assert!(
+            !json.contains("mtime"),
+            "mtime: None must not appear in serialized manifest, got: {json}"
+        );
+
+        // An old manifest blob (no mtime key at all) deserializes to None.
+        let old = r#"{"version":2,"file_hash":"deadbeef","file_size":3,"chunks":["c0"],"vclock":{"clocks":{}},"written_by":"neo","written_at":7,"rel_path":"a.txt","mode":420}"#;
+        let parsed = SyncManifest::from_bytes(old.as_bytes()).unwrap();
+        assert!(parsed.mtime.is_none());
+        assert_eq!(parsed.mode, Some(0o644));
     }
 
     #[test]
@@ -296,6 +344,7 @@ mod proptest_suite {
                 written_at,
                 rel_path: None,
                 mode: None,
+                mtime: None,
                 encrypted_file_key: None,
                 wrapped_file_keys: Vec::new(),
             };

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -856,30 +856,52 @@ pub async fn execute_plan(
                 local_path,
                 rel_path,
                 ..
-            } => match engine::upload_file_with_device(
-                op,
-                local_path,
-                remote_prefix,
-                state,
-                progress,
-                device_id,
-                Some(rel_path.as_str()),
-                encryption,
-            )
-            .await
-            {
-                Ok(upload) => {
-                    if !upload.skipped {
-                        result.pushed += 1;
-                        result.bytes_uploaded += upload.bytes;
+            } => {
+                // Symlinks (TIN-1620 T13-Z) are published as first-class link
+                // manifests, not run through the chunked-file uploader, which
+                // would otherwise dereference or fail on them. `symlink_metadata`
+                // does not follow the link, so we detect it without touching the
+                // target.
+                let is_symlink = std::fs::symlink_metadata(local_path)
+                    .map(|m| m.file_type().is_symlink())
+                    .unwrap_or(false);
+                let upload = if is_symlink {
+                    engine::upload_symlink_with_device(
+                        op,
+                        local_path,
+                        remote_prefix,
+                        state,
+                        device_id,
+                        rel_path.as_str(),
+                    )
+                    .await
+                } else {
+                    engine::upload_file_with_device(
+                        op,
+                        local_path,
+                        remote_prefix,
+                        state,
+                        progress,
+                        device_id,
+                        Some(rel_path.as_str()),
+                        encryption,
+                    )
+                    .await
+                };
+                match upload {
+                    Ok(upload) => {
+                        if !upload.skipped {
+                            result.pushed += 1;
+                            result.bytes_uploaded += upload.bytes;
+                        }
+                    }
+                    Err(e) => {
+                        result
+                            .errors
+                            .push((rel_path.clone(), format!("push failed: {e:#}")));
                     }
                 }
-                Err(e) => {
-                    result
-                        .errors
-                        .push((rel_path.clone(), format!("push failed: {e:#}")));
-                }
-            },
+            }
 
             ReconcileAction::Pull {
                 rel_path,
@@ -1110,6 +1132,14 @@ async fn execute_new_remote_pulls_concurrent(
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Collect local files into a `rel_path → PathBuf` map, applying the blacklist.
+///
+/// Tracked symlinks (git mode `120000`) are collected as links rather than
+/// dropped or dereferenced (TIN-1620 T13-Z): `preserve_symlinks: true` keeps
+/// them in their own `CollectResult::symlinks` bucket, which we fold into the
+/// same `rel_path → PathBuf` map so reconcile sees them. `follow_symlinks`
+/// stays `false` so we never walk *through* a link. The fail-closed deny-set
+/// guard in the collector still screens link targets before they reach here,
+/// and the push/restore paths below are symlink-aware.
 fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap<String, PathBuf>> {
     let config = crate::engine::CollectConfig {
         sync_git_dirs: blacklist.allows_git_dirs(),
@@ -1117,16 +1147,16 @@ fn collect_local_set(local_root: &Path, blacklist: &Blacklist) -> Result<HashMap
         sync_hidden_dirs: blacklist.allows_hidden_dirs(),
         exclude_patterns: blacklist.glob_patterns(),
         follow_symlinks: false,
-        preserve_symlinks: false,
+        preserve_symlinks: true,
         sync_empty_dirs: false, // reconcile only cares about files
     };
     let result = crate::engine::collect_files(local_root, &config)?;
 
     let mut map = HashMap::new();
-    for file in result.files {
-        if let Ok(rel) = file.strip_prefix(local_root) {
+    for entry in result.files.into_iter().chain(result.symlinks) {
+        if let Ok(rel) = entry.strip_prefix(local_root) {
             let rel_str = crate::engine::normalize_rel_path_text(&rel.to_string_lossy());
-            map.insert(rel_str, file);
+            map.insert(rel_str, entry);
         }
     }
     Ok(map)
@@ -1264,6 +1294,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1294,6 +1325,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1384,6 +1416,7 @@ mod tests {
             written_at: 0,
             rel_path: Some("doc.txt".into()),
             mode: None,
+            mtime: None,
             encrypted_file_key: None,
             wrapped_file_keys: Vec::new(),
         };
@@ -1739,6 +1772,126 @@ mod tests {
         let link_state = restore_state.get(&restore_root.join("link.txt")).unwrap();
         assert_eq!(link_state.status, crate::state::FileSyncStatus::Synced);
         assert_eq!(link_state.device_id, "honey");
+    }
+
+    /// (c) Symlink round-trips through reconcile's *push* path: a local-only
+    /// symlink is collected as a link (not dropped, not dereferenced), pushed as
+    /// a first-class symlink manifest, then restored on a fresh peer with its
+    /// target intact (TIN-1620 T13-Z). This exercises the new
+    /// `preserve_symlinks: true` collection plus the symlink-aware push dispatch.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_push_then_restore_round_trips_symlink() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let restore_root = dir.path().join("restore");
+        std::fs::create_dir_all(&source_root).unwrap();
+        std::fs::create_dir_all(&restore_root).unwrap();
+
+        // Source has a regular file plus a tracked symlink pointing at it.
+        std::fs::write(source_root.join("target.txt"), b"target body").unwrap();
+        std::os::unix::fs::symlink("target.txt", source_root.join("link.txt")).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        // 1. The source side reconciles: the symlink must surface as a Push, not
+        //    be silently dropped by collection.
+        let mut source_state =
+            crate::state::StateCache::open(&dir.path().join("source-state.json")).unwrap();
+        let push_plan = reconcile(
+            &op,
+            &source_root,
+            "data",
+            &source_state,
+            "neo",
+            &blacklist,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert!(
+            push_plan.actions.iter().any(|a| matches!(
+                a,
+                ReconcileAction::Push { rel_path, .. } if rel_path == "link.txt"
+            )),
+            "symlink must be collected and planned as a push, got {:?}",
+            push_plan.summary
+        );
+
+        let push_result = execute_plan(
+            &push_plan,
+            &op,
+            &source_root,
+            "data",
+            &mut source_state,
+            "neo",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(push_result.errors.is_empty(), "{:?}", push_result.errors);
+
+        // The published manifest must be a symlink manifest, not a regular-file
+        // one that dereferenced the link into target bytes.
+        let manifest_bytes = op.read("data/index/link.txt").await.unwrap().to_vec();
+        let entry = crate::index_entry::parse_index_entry_record(&manifest_bytes).unwrap();
+        let manifest_hash = match entry {
+            crate::index_entry::ParsedIndexEntry::Legacy(e) => e.manifest_hash,
+            crate::index_entry::ParsedIndexEntry::V2(e) => e.current.unwrap().manifest_hash,
+        };
+        let published = op
+            .read(&format!("data/manifests/{manifest_hash}"))
+            .await
+            .unwrap()
+            .to_vec();
+        let sym = crate::manifest::SymlinkManifest::from_bytes(&published)
+            .expect("published manifest must be a symlink manifest, not dereferenced content");
+        assert_eq!(sym.symlink_target, "target.txt");
+
+        // 2. A fresh peer restores: the link comes back as a link with the same
+        //    target, never dereferenced into a copy of the file.
+        let mut restore_state =
+            crate::state::StateCache::open(&dir.path().join("restore-state.json")).unwrap();
+        let pull_plan = reconcile(
+            &op,
+            &restore_root,
+            "data",
+            &restore_state,
+            "honey",
+            &blacklist,
+            &config,
+        )
+        .await
+        .unwrap();
+        let pull_result = execute_plan(
+            &pull_plan,
+            &op,
+            &restore_root,
+            "data",
+            &mut restore_state,
+            "honey",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(pull_result.errors.is_empty(), "{:?}", pull_result.errors);
+
+        let restored_link = restore_root.join("link.txt");
+        assert!(
+            std::fs::symlink_metadata(&restored_link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "restored entry must be a symlink, not a dereferenced regular file"
+        );
+        assert_eq!(
+            std::fs::read_link(&restored_link).unwrap(),
+            PathBuf::from("target.txt")
+        );
     }
 
     // ── reconcile plan: both exist, up-to-date ───────────────────────────

--- a/crates/tcfs-sync/src/reconcile.rs
+++ b/crates/tcfs-sync/src/reconcile.rs
@@ -23,7 +23,7 @@ use crate::engine::{self, OptionalEncryption, ProgressFn};
 use crate::index_entry::{
     manifest_key, parse_index_entry_record, resolve_visible_index_entry, RemoteIndexEntry,
 };
-use crate::manifest::SyncManifest;
+use crate::manifest::{SymlinkManifest, SyncManifest};
 use crate::state::{StateCache, StateCacheBackend, SyncState};
 
 const REMOTE_INDEX_READ_CONCURRENCY: usize = 32;
@@ -713,6 +713,28 @@ async fn compare_both_exist(
     remote_prefix: &str,
     device_id: &str,
 ) -> ReconcileAction {
+    // Symlinks are first-class entries: they must NOT be dereferenced and hashed
+    // like regular files (that would hash the *target's* content and then fail to
+    // parse the stored SymlinkManifest as a SyncManifest, re-pushing every cycle).
+    // Detect a local symlink with symlink_metadata (does not follow the link) and
+    // compare on symlink identity instead. Mirrors the push path
+    // (`upload_symlink_with_device`) and `collect_local_set` (preserve_symlinks).
+    let local_is_symlink = std::fs::symlink_metadata(local_path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    if local_is_symlink {
+        return compare_both_exist_symlink(
+            rel_path,
+            local_path,
+            remote_entry,
+            tracked,
+            op,
+            remote_prefix,
+            device_id,
+        )
+        .await;
+    }
+
     // Get local hash
     let local_hash = match tcfs_chunks::hash_file(local_path) {
         Ok(h) => tcfs_chunks::hash_to_hex(&h),
@@ -763,6 +785,105 @@ async fn compare_both_exist(
         &remote_manifest.vclock,
         &local_hash,
         &remote_manifest.file_hash,
+        rel_path,
+        device_id,
+        remote_device,
+    );
+
+    match outcome {
+        crate::conflict::SyncOutcome::UpToDate => ReconcileAction::UpToDate {
+            rel_path: rel_path.to_string(),
+        },
+        crate::conflict::SyncOutcome::LocalNewer => ReconcileAction::Push {
+            local_path: local_path.to_path_buf(),
+            rel_path: rel_path.to_string(),
+            reason: PushReason::LocalNewer,
+        },
+        crate::conflict::SyncOutcome::RemoteNewer => ReconcileAction::Pull {
+            rel_path: rel_path.to_string(),
+            manifest_hash: remote_entry.manifest_hash.clone(),
+            size: remote_entry.size,
+            reason: PullReason::RemoteNewer,
+        },
+        crate::conflict::SyncOutcome::Conflict(info) => ReconcileAction::Conflict {
+            rel_path: rel_path.to_string(),
+            info,
+        },
+    }
+}
+
+/// Compare when both sides exist and the local entry is a symbolic link.
+///
+/// Symlink identity is the link target text, hashed via
+/// `engine::symlink_manifest_hash` — the SAME identity the push path
+/// (`upload_symlink_with_device`) writes into the manifest hash, the remote
+/// index entry, and the local sync-state `blake3`. Comparing those identities
+/// through `compare_clocks` reuses the regular-file conflict/pull/push logic:
+/// identical targets short-circuit to UpToDate, divergent targets fall through
+/// to the vector-clock decision (Push / Pull / Conflict). This fixes the
+/// steady-state defect where a tracked symlink was re-pushed every cycle.
+async fn compare_both_exist_symlink(
+    rel_path: &str,
+    local_path: &Path,
+    remote_entry: &RemoteIndexEntry,
+    tracked: Option<&SyncState>,
+    op: &Operator,
+    remote_prefix: &str,
+    device_id: &str,
+) -> ReconcileAction {
+    // Read the local link target without following it.
+    let local_target = match crate::engine::read_symlink_target_text(local_path) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!(path = %local_path.display(), error = %e, "failed to read local symlink target");
+            return ReconcileAction::UpToDate {
+                rel_path: rel_path.to_string(),
+            };
+        }
+    };
+    let local_hash = crate::engine::symlink_manifest_hash(&local_target);
+    let local_vclock = tracked.map(|s| s.vclock.clone()).unwrap_or_default();
+
+    // Fetch and parse the remote manifest as a SymlinkManifest — the exact type
+    // the push path serialized. Failing closed: if the remote entry is not a
+    // symlink manifest (kind/version mismatch or unreadable), fall back to the
+    // conservative re-push so we never silently treat a mismatched remote as
+    // up-to-date.
+    let manifest_path = format!(
+        "{}/manifests/{}",
+        remote_prefix.trim_end_matches('/'),
+        &remote_entry.manifest_hash
+    );
+    let remote_manifest = match op.read(&manifest_path).await {
+        Ok(data) => match SymlinkManifest::from_bytes(&data.to_vec()) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(path = manifest_path, error = %e, "failed to parse remote symlink manifest");
+                return ReconcileAction::Push {
+                    local_path: local_path.to_path_buf(),
+                    rel_path: rel_path.to_string(),
+                    reason: PushReason::NewLocal,
+                };
+            }
+        },
+        Err(e) => {
+            warn!(path = manifest_path, error = %e, "failed to read remote symlink manifest");
+            return ReconcileAction::Push {
+                local_path: local_path.to_path_buf(),
+                rel_path: rel_path.to_string(),
+                reason: PushReason::NewLocal,
+            };
+        }
+    };
+
+    let remote_hash = crate::engine::symlink_manifest_hash(&remote_manifest.symlink_target);
+    let remote_device = remote_manifest.written_by.as_str();
+
+    let outcome = compare_clocks(
+        &local_vclock,
+        &remote_manifest.vclock,
+        &local_hash,
+        &remote_hash,
         rel_path,
         device_id,
         remote_device,
@@ -2022,6 +2143,121 @@ mod tests {
         assert_eq!(plan.summary.pushes, 0);
         assert_eq!(plan.summary.pulls, 0);
         assert_eq!(plan.summary.conflicts, 0);
+    }
+
+    // ── reconcile plan: tracked symlink converges (steady state) ─────────
+    //
+    // Regression for the symlink steady-state convergence defect: a tracked
+    // symlink present on BOTH local and remote must reconcile to UpToDate on
+    // every subsequent cycle, not re-Push forever. The remote here is written
+    // by `upload_symlink_with_device`, the same primitive `push_tree` uses, so
+    // the index entry, manifest, and local sync state match production exactly.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_tracked_symlink_converges_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path().join("repo");
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        // A real regular file plus a tracked symlink that points at it.
+        std::fs::write(local_root.join("target.txt"), b"target").unwrap();
+        let link = local_root.join("link.txt");
+        std::os::unix::fs::symlink("target.txt", &link).unwrap();
+
+        // First reconcile cycle: push the symlink to the remote, recording the
+        // symlink sync state (blake3 = symlink_manifest_hash(target)) keyed on
+        // the live local path. This stands in for the prior successful push.
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        crate::engine::upload_symlink_with_device(
+            &op, &link, "data", &mut state, "neo", "link.txt",
+        )
+        .await
+        .unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        // Second reconcile cycle against the SAME local tree + remote: the
+        // symlink exists on both sides and is tracked, so it must converge.
+        let plan = reconcile(&op, &local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        let link_action = plan.actions.iter().find(|a| match a {
+            ReconcileAction::UpToDate { rel_path }
+            | ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::Conflict { rel_path, .. } => rel_path == "link.txt",
+            _ => false,
+        });
+        assert!(
+            matches!(link_action, Some(ReconcileAction::UpToDate { .. })),
+            "tracked unchanged symlink must converge to UpToDate, got {link_action:?}"
+        );
+        assert!(
+            !plan.actions.iter().any(
+                |a| matches!(a, ReconcileAction::Push { rel_path, .. } if rel_path == "link.txt")
+            ),
+            "tracked unchanged symlink must not re-push on a steady-state cycle"
+        );
+    }
+
+    // A *changed* symlink target must still be detected as a divergence so the
+    // fix is not a vacuous "always UpToDate".
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconcile_changed_symlink_target_is_not_up_to_date() {
+        let op = memory_op();
+        let dir = tempfile::tempdir().unwrap();
+        let local_root = dir.path().join("repo");
+        std::fs::create_dir_all(&local_root).unwrap();
+
+        std::fs::write(local_root.join("a.txt"), b"a").unwrap();
+        std::fs::write(local_root.join("b.txt"), b"b").unwrap();
+        let link = local_root.join("link.txt");
+        std::os::unix::fs::symlink("a.txt", &link).unwrap();
+
+        // Push the symlink pointing at a.txt, recording its sync state.
+        let state_path = dir.path().join("state.json");
+        let mut state = crate::state::StateCache::open(&state_path).unwrap();
+        crate::engine::upload_symlink_with_device(
+            &op, &link, "data", &mut state, "neo", "link.txt",
+        )
+        .await
+        .unwrap();
+
+        // Repoint the local symlink at b.txt without re-syncing: local diverges
+        // from the tracked + remote target.
+        std::fs::remove_file(&link).unwrap();
+        std::os::unix::fs::symlink("b.txt", &link).unwrap();
+
+        let blacklist = Blacklist::default();
+        let config = ReconcileConfig::default();
+
+        let plan = reconcile(&op, &local_root, "data", &state, "neo", &blacklist, &config)
+            .await
+            .unwrap();
+
+        let link_action = plan.actions.iter().find(|a| match a {
+            ReconcileAction::UpToDate { rel_path }
+            | ReconcileAction::Push { rel_path, .. }
+            | ReconcileAction::Pull { rel_path, .. }
+            | ReconcileAction::Conflict { rel_path, .. } => rel_path == "link.txt",
+            _ => false,
+        });
+        assert!(
+            !matches!(link_action, Some(ReconcileAction::UpToDate { .. })),
+            "a changed symlink target must not be classified UpToDate, got {link_action:?}"
+        );
+        assert!(
+            matches!(
+                link_action,
+                Some(ReconcileAction::Push { .. }) | Some(ReconcileAction::Conflict { .. })
+            ),
+            "a changed symlink target must surface as Push/Conflict, got {link_action:?}"
+        );
     }
     // ── original tests ───────────────────────────────────────────────────
 

--- a/crates/tcfs-sync/tests/multi_machine_sim.rs
+++ b/crates/tcfs-sync/tests/multi_machine_sim.rs
@@ -179,6 +179,7 @@ fn execute_op(
                 written_at: 0,
                 rel_path: Some(path.clone()),
                 mode: None,
+                mtime: None,
                 encrypted_file_key: None,
                 wrapped_file_keys: Vec::new(),
             };
@@ -916,6 +917,7 @@ fn test_manifest_serialization_in_sim() {
         written_at: 1000,
         rel_path: Some("src/main.rs".into()),
         mode: None,
+        mtime: None,
         encrypted_file_key: None,
         wrapped_file_keys: Vec::new(),
     };

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -14,7 +14,7 @@ use secrecy::ExposeSecret;
 use tempfile::TempDir;
 
 use tcfs_crypto::AgeFileKeyRecipient;
-use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
+use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext, WrapMode};
 
 fn memory_operator() -> Operator {
     Operator::new(opendal::services::Memory::default())
@@ -171,4 +171,187 @@ async fn revoked_device_cannot_decrypt_new_content() {
     .await
     .expect("active device download should succeed");
     assert_eq!(std::fs::read(&dst_a).unwrap(), content);
+}
+
+// ── TIN-1417: tri-state wrap_mode write-path shapes + v3 fail-closed ────────
+
+async fn upload_with_ctx(
+    op: &Operator,
+    tmp: &TempDir,
+    prefix: &str,
+    ctx: &EncryptionContext,
+    content: &[u8],
+) -> tcfs_sync::manifest::SyncManifest {
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+    let up = tcfs_sync::engine::upload_file_with_device(
+        op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(ctx),
+    )
+    .await
+    .expect("upload should succeed");
+    let bytes = op.read(&up.remote_path).await.unwrap().to_bytes();
+    tcfs_sync::manifest::SyncManifest::from_bytes(&bytes).unwrap()
+}
+
+/// Master mode (DEFAULT): master-wrapped key only, no per-device wraps, v2.
+#[tokio::test]
+async fn wrap_mode_master_emits_encrypted_file_key_only_v2() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    // Even with recipients/identity attached, Master must emit master-only.
+    let ctx =
+        EncryptionContext::new(master()).with_wrap_mode(WrapMode::Master, vec![rec_a], Some(id_a));
+    let manifest = upload_with_ctx(&op, &tmp, "test/master", &ctx, b"master payload").await;
+    assert_eq!(manifest.version, 2, "Master stays manifest v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Master must emit the master-wrapped key"
+    );
+    assert!(
+        manifest.wrapped_file_keys.is_empty(),
+        "Master must NOT emit per-device wraps"
+    );
+}
+
+/// Dual mode (EXPAND): BOTH master wrap and per-device wraps, stays v2.
+#[tokio::test]
+async fn wrap_mode_dual_emits_both_fields_v2() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, _id_b) = device("device-b");
+    let ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::Dual,
+        vec![rec_a, rec_b],
+        Some(id_a),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, "test/dual", &ctx, b"dual payload").await;
+    assert_eq!(manifest.version, 2, "Dual is back-compatible: stays v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Dual must emit the master wrap (rollback + master readers)"
+    );
+    assert_eq!(
+        manifest.wrapped_file_keys.len(),
+        2,
+        "Dual must also emit one per-device wrap per recipient"
+    );
+}
+
+/// PerDevice mode (CONTRACT): per-device wraps only, master wrap dropped, v3.
+#[tokio::test]
+async fn wrap_mode_per_device_emits_wrapped_only_v3() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let (rec_a, id_a) = device("device-a");
+    let ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::PerDevice,
+        vec![rec_a],
+        Some(id_a.clone()),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, "test/perdev", &ctx, b"per-device payload").await;
+    assert_eq!(manifest.version, 3, "PerDevice bumps the manifest to v3");
+    assert!(
+        manifest.encrypted_file_key.is_none(),
+        "PerDevice must DROP the master wrap (true revocation)"
+    );
+    assert!(
+        !manifest.wrapped_file_keys.is_empty(),
+        "PerDevice must emit per-device wraps"
+    );
+}
+
+/// Dual/PerDevice with no recipients must FAIL CLOSED rather than silently
+/// degrading to master-only / writing an unreadable manifest.
+#[tokio::test]
+async fn dual_and_per_device_without_recipients_fail_closed() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, b"x").unwrap();
+
+    for mode in [WrapMode::Dual, WrapMode::PerDevice] {
+        let ctx = EncryptionContext::new(master()).with_wrap_mode(mode, Vec::new(), None);
+        let res = tcfs_sync::engine::upload_file_with_device(
+            &op,
+            &src,
+            "test/failclosed",
+            &mut state,
+            None,
+            "device-a",
+            None,
+            Some(&ctx),
+        )
+        .await;
+        assert!(
+            res.is_err(),
+            "wrap_mode={mode:?} with no recipients must fail closed"
+        );
+    }
+}
+
+/// A v3 (per-device) manifest must be REJECTED fail-closed by a master-only read
+/// context (a binary/context without a per-device identity).
+#[tokio::test]
+async fn v3_manifest_rejected_fail_closed_by_master_only_read() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/v3-failclosed";
+    let (rec_a, id_a) = device("device-a");
+    let write_ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::PerDevice,
+        vec![rec_a],
+        Some(id_a),
+    );
+    let manifest = upload_with_ctx(&op, &tmp, prefix, &write_ctx, b"v3 payload").await;
+    assert_eq!(manifest.version, 3);
+
+    // Reconstruct the remote manifest path the same way upload did.
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state2.db")).unwrap();
+    let src = tmp.path().join("doc.txt");
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .unwrap();
+
+    // Master-only context: no device identity attached -> must fail closed.
+    let master_only = EncryptionContext::new(master());
+    let dst = tmp.path().join("out.txt");
+    let res = tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        "device-a",
+        None,
+        Some(&master_only),
+    )
+    .await;
+    assert!(
+        res.is_err(),
+        "a master-only context must reject a v3 per-device manifest (fail-closed)"
+    );
+    assert!(
+        !dst.exists(),
+        "fail-closed read must not materialize a file"
+    );
 }

--- a/crates/tcfs-sync/tests/per_device_wrap_test.rs
+++ b/crates/tcfs-sync/tests/per_device_wrap_test.rs
@@ -300,6 +300,82 @@ async fn dual_and_per_device_without_recipients_fail_closed() {
     }
 }
 
+/// A Dual (v2) manifest carries BOTH a master wrap and per-device wraps. A
+/// Master-mode / no-identity read context (e.g. a peer device that never
+/// attached an age identity) MUST fall back to the master wrap and hydrate exact
+/// bytes — NOT error "no age identity". This is the whole point of Dual's
+/// rollback/recovery rationale and the live daemon/FP read path for a Master
+/// device reading peer-written Dual content.
+#[tokio::test]
+async fn dual_manifest_master_only_read_falls_back_to_master_wrap() {
+    let tmp = TempDir::new().unwrap();
+    let op = memory_operator();
+    let prefix = "test/dual-master-read";
+    let mut state = tcfs_sync::state::StateCache::open(&tmp.path().join("state.db")).unwrap();
+
+    // Write in Dual mode: recipients + identity attached, master wrap retained.
+    let (rec_a, id_a) = device("device-a");
+    let (rec_b, _id_b) = device("device-b");
+    let write_ctx = EncryptionContext::new(master()).with_wrap_mode(
+        WrapMode::Dual,
+        vec![rec_a, rec_b],
+        Some(id_a),
+    );
+
+    let content = b"dual payload readable by a master-only device with no age identity";
+    let src = tmp.path().join("doc.txt");
+    std::fs::write(&src, content).unwrap();
+
+    let up = tcfs_sync::engine::upload_file_with_device(
+        &op,
+        &src,
+        prefix,
+        &mut state,
+        None,
+        "device-a",
+        None,
+        Some(&write_ctx),
+    )
+    .await
+    .expect("dual upload should succeed");
+
+    // Sanity: the manifest is a real Dual manifest (v2, both fields present).
+    let manifest_bytes = op.read(&up.remote_path).await.unwrap().to_bytes();
+    let manifest = tcfs_sync::manifest::SyncManifest::from_bytes(&manifest_bytes).unwrap();
+    assert_eq!(manifest.version, 2, "Dual stays manifest v2");
+    assert!(
+        manifest.encrypted_file_key.is_some(),
+        "Dual must retain the master wrap"
+    );
+    assert!(
+        !manifest.wrapped_file_keys.is_empty(),
+        "Dual must also carry per-device wraps"
+    );
+
+    // Read back with a pure master context: NO device identity attached. The
+    // read switch must NOT error "no age identity"; it must fall back to the
+    // master wrap and produce byte-exact plaintext.
+    let master_only = EncryptionContext::new(master());
+    let dst = tmp.path().join("out.txt");
+    tcfs_sync::engine::download_file_with_device(
+        &op,
+        &up.remote_path,
+        &dst,
+        prefix,
+        None,
+        "master-reader",
+        None,
+        Some(&master_only),
+    )
+    .await
+    .expect("master-only read of a Dual manifest must succeed via master-wrap fallback");
+    assert_eq!(
+        std::fs::read(&dst).unwrap(),
+        content,
+        "master-wrap fallback must reconstruct exact plaintext"
+    );
+}
+
 /// A v3 (per-device) manifest must be REJECTED fail-closed by a master-only read
 /// context (a binary/context without a per-device identity).
 #[tokio::test]

--- a/crates/tcfs-vfs/src/driver.rs
+++ b/crates/tcfs-vfs/src/driver.rs
@@ -347,6 +347,7 @@ impl TcfsVfs {
             written_at: now,
             rel_path: Some(vpath.to_string()),
             mode: None,
+            mtime: None,
             encrypted_file_key,
             wrapped_file_keys: Vec::new(),
         };

--- a/crates/tcfsd/src/daemon.rs
+++ b/crates/tcfsd/src/daemon.rs
@@ -243,6 +243,31 @@ pub async fn run(config: TcfsConfig) -> Result<()> {
         warn!("E2E encryption: configured but master key unavailable");
     }
 
+    // TIN-1417 B4: ensure the on-disk device registry is signed with the
+    // master-derived key. The auto-enroll above runs before the master key is
+    // available, so a first-run registry is written unsigned; re-sign it here so
+    // per-device wrapping can trust it. Best-effort: a load/verify failure here
+    // (e.g. a registry signed by a *different* master) is logged, not fatal.
+    if let Some(ref mk) = master_key {
+        match tcfs_secrets::device::DeviceRegistry::load_verified(&registry_path, mk.as_bytes()) {
+            Ok((_, tcfs_secrets::device::RegistryTrust::Signed)) => {}
+            Ok((mut reg, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+                if let Err(e) = reg.save_signed(&registry_path, mk.as_bytes()) {
+                    warn!("TIN-1417 B4: failed to sign device registry: {e}");
+                } else {
+                    info!("TIN-1417 B4: signed previously-unsigned device registry");
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "TIN-1417 B4: device registry failed signature verification ({e}); leaving \
+                     as-is. Per-device wrapping will refuse to trust it until re-signed with the \
+                     correct master key."
+                );
+            }
+        }
+    }
+
     // Build storage operator and verify connectivity
     let mut operator: Option<opendal::Operator> = None;
     let storage_ok = if let Some(s3) = cred_store.read().await.as_ref().and_then(|c| c.s3.as_ref())

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -1603,6 +1603,7 @@ impl TcfsDaemon for TcfsDaemonImpl {
                     written_at: tcfs_sync::StateEvent::now(),
                     rel_path: Some(req.path.clone()),
                     mode: None,
+                    mtime: None,
                     encrypted_file_key: None,
                     wrapped_file_keys: Vec::new(),
                 };

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -58,11 +58,27 @@ pub(crate) fn build_encryption_context(
         .device_identity
         .clone()
         .unwrap_or_else(tcfs_secrets::device::default_registry_path);
-    let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
-        Ok(r) => r,
+    // TIN-1417 B4: the recipient set MUST come from a signature-VERIFIED registry.
+    // A tampered/unsigned registry must never source per-device recipients —
+    // fall back to the shared master wrap (and warn) instead of wrapping to an
+    // unverified, possibly-hostile recipient.
+    let registry = match tcfs_secrets::device::DeviceRegistry::load_verified(
+        &registry_path,
+        master_key.as_bytes(),
+    ) {
+        Ok((r, tcfs_secrets::device::RegistryTrust::Signed)) => r,
+        Ok((_, tcfs_secrets::device::RegistryTrust::UnsignedLegacy)) => {
+            tracing::warn!(
+                "wrap_mode={requested:?}: device registry is UNSIGNED (legacy); refusing to \
+                 build a per-device recipient set from an unverified registry — using master \
+                 wrap. Re-save the registry with a master-key command to sign it."
+            );
+            return base;
+        }
         Err(e) => {
             tracing::warn!(
-                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+                "wrap_mode={requested:?}: device registry FAILED signature verification ({e}); \
+                 refusing per-device recipients — using master wrap (fail-closed)"
             );
             return base;
         }

--- a/crates/tcfsd/src/grpc.rs
+++ b/crates/tcfsd/src/grpc.rs
@@ -24,22 +24,35 @@ use tcfs_core::proto::{
 };
 use tcfs_sync::state::StateCacheBackend;
 
-/// Build an `EncryptionContext`, attaching per-device wrapping (TIN-1417) when
-/// `crypto.per_device_wrapping` is enabled and the device registry has real age
-/// recipients. Falls back to legacy shared-master wrapping (and logs why) if the
-/// registry can't be loaded, has no real recipients, or this device's age secret
-/// is missing — never producing content this device cannot read back.
+/// Build an `EncryptionContext` honoring `crypto.wrap_mode` (TIN-1417).
+///
+/// - `Master` (default): legacy shared-master wrap. Byte-identical to the prior
+///   default; returns `EncryptionContext::new(master_key)` verbatim.
+/// - `Dual` (EXPAND): emit BOTH the master wrap and per-device wraps. Requires a
+///   real age recipient set; if none are available we log and fall back to
+///   master (never produce content this device cannot read back).
+/// - `PerDevice` (CONTRACT): drop the master wrap. Gated behind a roll-call
+///   probe — we refuse PerDevice and **fall back to Dual + warn loudly** unless
+///   EVERY active (non-revoked) device carries a real age recipient. We also
+///   fall back if the local device secret is unreadable.
+///
+/// Whenever the requested mode cannot be honored safely we degrade to the most
+/// conservative mode that still keeps every device able to read (Dual, then
+/// Master), and log why — we never silently drop the master fallback.
 pub(crate) fn build_encryption_context(
     config: &TcfsConfig,
     device_id: &str,
     master_key: &tcfs_crypto::MasterKey,
 ) -> tcfs_sync::engine::EncryptionContext {
+    use tcfs_core::config::WrapMode;
     use tcfs_sync::engine::{DeviceUnwrapIdentity, EncryptionContext};
 
     let base = EncryptionContext::new(master_key.clone());
-    if !config.crypto.per_device_wrapping {
+    let requested = config.crypto.wrap_mode;
+    if requested == WrapMode::Master {
         return base;
     }
+
     let registry_path = config
         .sync
         .device_identity
@@ -48,10 +61,13 @@ pub(crate) fn build_encryption_context(
     let registry = match tcfs_secrets::device::DeviceRegistry::load(&registry_path) {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!("per-device wrapping: registry load failed ({e}); using master wrap");
+            tracing::warn!(
+                "wrap_mode={requested:?}: registry load failed ({e}); using master wrap"
+            );
             return base;
         }
     };
+
     let recipients: Vec<tcfs_crypto::AgeFileKeyRecipient> = registry
         .active_devices()
         .filter(|d| tcfs_secrets::device::is_real_age_public_key(&d.public_key))
@@ -62,10 +78,11 @@ pub(crate) fn build_encryption_context(
         .collect();
     if recipients.is_empty() {
         tracing::warn!(
-            "per-device wrapping enabled but no active age recipients; using master wrap"
+            "wrap_mode={requested:?} enabled but no active age recipients; using master wrap"
         );
         return base;
     }
+
     let secret_path = tcfs_secrets::device::device_secret_key_path(&registry_path, device_id);
     let identity = match std::fs::read_to_string(&secret_path) {
         Ok(s) => DeviceUnwrapIdentity {
@@ -74,12 +91,44 @@ pub(crate) fn build_encryption_context(
         },
         Err(e) => {
             tracing::warn!(
-                "per-device wrapping: local device secret unreadable ({e}); using master wrap"
+                "wrap_mode={requested:?}: local device secret unreadable ({e}); using master wrap"
             );
             return base;
         }
     };
-    base.with_device_wrapping(recipients, Some(identity))
+
+    // Roll-call gate: PerDevice (CONTRACT) drops the master wrap, so it is only
+    // safe when EVERY active device can do per-device unwrap. If not, degrade to
+    // Dual (keeps the master fallback) and warn loudly.
+    let effective = resolve_wrap_mode_with_roll_call(requested, &registry);
+    base.with_wrap_mode(effective, recipients, Some(identity))
+}
+
+/// Apply the roll-call gate to a requested wrap mode.
+///
+/// `PerDevice` is downgraded to `Dual` (with a loud warning) unless every active
+/// device carries a real age recipient. `Master`/`Dual` pass through unchanged.
+pub(crate) fn resolve_wrap_mode_with_roll_call(
+    requested: tcfs_core::config::WrapMode,
+    registry: &tcfs_secrets::device::DeviceRegistry,
+) -> tcfs_core::config::WrapMode {
+    use tcfs_core::config::WrapMode;
+    if requested != WrapMode::PerDevice {
+        return requested;
+    }
+    let roll_call = registry.roll_call();
+    if roll_call.all_capable() {
+        return WrapMode::PerDevice;
+    }
+    tracing::warn!(
+        active = roll_call.active,
+        capable = roll_call.capable,
+        blockers = ?roll_call.incapable_devices,
+        "wrap_mode=PerDevice REFUSED by roll-call gate: not every active device has a real \
+         age recipient; falling back to Dual (keeping the master wrap) to avoid locking out \
+         devices. Enroll real age recipients for the listed devices to enable true revocation."
+    );
+    WrapMode::Dual
 }
 
 /// Implementation of the TcfsDaemon gRPC service
@@ -4046,5 +4095,49 @@ mod tests {
             "docs/nested/deep.md"
         );
         assert_eq!(sanitize_rel_path("./current.txt").unwrap(), "./current.txt");
+    }
+
+    // ── TIN-1417: roll-call gate for the PerDevice CONTRACT ────────────────
+
+    #[test]
+    fn roll_call_gate_passes_per_device_when_all_capable() {
+        use tcfs_core::config::WrapMode;
+        let mut reg = tcfs_secrets::device::DeviceRegistry::default();
+        let real = tcfs_secrets::device::generate_local_device_key().public_key;
+        reg.enroll("a", &real, None);
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::PerDevice, &reg),
+            WrapMode::PerDevice,
+            "all active devices capable => PerDevice honored"
+        );
+    }
+
+    #[test]
+    fn roll_call_gate_downgrades_per_device_to_dual_when_blocked() {
+        use tcfs_core::config::WrapMode;
+        let mut reg = tcfs_secrets::device::DeviceRegistry::default();
+        let real = tcfs_secrets::device::generate_local_device_key().public_key;
+        reg.enroll("a", &real, None);
+        // A second active device without a real age recipient blocks the contract.
+        reg.enroll("placeholder", "age1xoxd-not-a-real-key", None);
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::PerDevice, &reg),
+            WrapMode::Dual,
+            "a non-capable active device must downgrade PerDevice -> Dual"
+        );
+    }
+
+    #[test]
+    fn roll_call_gate_passes_dual_and_master_through() {
+        use tcfs_core::config::WrapMode;
+        let reg = tcfs_secrets::device::DeviceRegistry::default();
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::Master, &reg),
+            WrapMode::Master
+        );
+        assert_eq!(
+            resolve_wrap_mode_with_roll_call(WrapMode::Dual, &reg),
+            WrapMode::Dual
+        );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,7 @@ targets = [
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
     "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ targets = [
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
+    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,6 @@ targets = [
 [advisories]
 ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained — transitive dep, no direct usage
-    "RUSTSEC-2026-0097",  # rand 0.8.5 unsound with custom logger — transitive via age, no custom logger in TCFS
     "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained — build-time proc-macro dep via age→i18n-embed-fl; no runtime or security impact
     # RUSTSEC-2025-0067/0068 removed: serde_yml migrated to serde_norway
 ]

--- a/docs/ops/claude-projects-roam-enrollment-2026-06-08.md
+++ b/docs/ops/claude-projects-roam-enrollment-2026-06-08.md
@@ -1,0 +1,450 @@
+# Roam Enrollment: `~/.claude/projects` via a Scheduled `tcfs reconcile` Unit
+
+**Status:** spec / ready-to-apply (agent-drafted, needs operator review)
+**Date:** 2026-06-08
+**Track:** A (roam enrollment of a disjoint tree)
+**Target hosts:** `macbook-neo` (Darwin), `honey` (Linux)
+**Shared convergence prefix:** `agent/claude-projects`
+
+---
+
+## 0. Why this is a scheduled `reconcile` unit and not a `sync_root` change
+
+TCFS has exactly **one** `sync_root` (rendered from `tinyland.tummycrypt.mount.path`,
+`config.rs` / `tummycrypt.nix:171`). `~/.claude/projects` is a **disjoint tree**
+(733 MB, append-only JSONL, 0 symlinks, no `.git`) that lives **outside** the TCFS
+mount, so it cannot be folded into the daemon's single `sync_root` or its FileProvider
+read path.
+
+The enrollment vehicle is therefore the **CLI `reconcile` engine**, scheduled out of
+band:
+
+```
+tcfs reconcile --path ~/.claude/projects --prefix agent/claude-projects --execute
+```
+
+This is the same diff/push/pull engine the daemon uses (`crates/tcfs-sync/src/reconcile.rs`),
+with the **same fail-closed security deny-set** (`Blacklist::from_sync_config`, applied
+in `collect_local_set`). The periodic reconcile is **NOT FileProvider-gated** — it only
+needs S3 credentials and (for the unlocked master key) the running daemon. It runs even
+on hosts where the FileProvider extension is disabled.
+
+Key facts that shape the unit (all verified against `origin/main @ c7f725c`):
+
+| Fact | Source | Consequence |
+|---|---|---|
+| `reconcile` flags are `--path`/`-p`, `--prefix`, `--execute`, `--state`/`TCFS_STATE_PATH` | `tcfs-cli/src/main.rs:275` | Unit invokes exactly these |
+| Default is **dry-run**; `--execute` applies | `main.rs:282` | Unit MUST pass `--execute` |
+| Crypto forces **serial** file upload (the parallel fast-path is gated when `encryption_present`) | `tcfs-sync/src/engine.rs:182` | First 733 MB push is ~10-30 min |
+| `TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1` skips redundant remote HEADs on a known-empty prefix | `engine.rs:151-161` | Set it for the **first bulk** push only |
+| Security deny-set is fail-closed and applied before the plan is built | `blacklist.rs:171`, `reconcile.rs:525` | Secrets never enter a push plan |
+| `reconcile` is not FileProvider-gated | `main.rs:803` (no `fileProvider` guard) | Runs on neo (FP on) and honey (no FP) |
+
+Because the reconcile uses the daemon's **master-wrapped** crypto context
+(`build_encryption_context`, `WrapMode::Master` default), the bytes pushed to
+`agent/claude-projects` are byte-identical in wrap shape to the existing `data`
+prefix. **No wrap_mode change.** Convergence is proven by SHA256-after-decrypt on the
+shared prefix.
+
+`policy_file` / `sync-policy.toml` is a dead knob (zero `.rs` consumers) and is not
+involved here. `reconcile_interval_secs` (config.rs default 300) is the daemon's own
+loop, not this unit; this unit carries its own cadence via the launchd `StartInterval` /
+systemd `OnUnitActiveSec`.
+
+---
+
+## 1. Concrete nix to paste into `nix/home-manager/tummycrypt.nix`
+
+All three blocks below are paste-ready. They reuse the module's existing
+`let`-block builders (`tcfsCliBin`, `socketPath`, `config.home.profileDirectory`,
+the `*_FILE` sops-nix credential pattern from `daemonWrapper`/`mountWrapper`,
+`config.xdg.stateHome`, `homeDir`). They introduce **one** new option
+(`extraReconcileRoots`) and **one** new builder (`tcfsReconcileScript`).
+
+### 1a. Option declaration
+
+Add inside `options.tinyland.tummycrypt = { … }`, e.g. directly after the
+`mount = { … };` block (around `tummycrypt.nix:557`). This mirrors the existing
+`secrets.syncList` submodule-list style already in the module
+(`tummycrypt.nix:895`).
+
+```nix
+    # =========================================================================
+    # Extra Reconcile Roots (Track A — roam enrollment of disjoint trees)
+    # =========================================================================
+    # Schedules `tcfs reconcile --path <path> --prefix <prefix> --execute` for
+    # trees that live OUTSIDE the single sync_root (e.g. ~/.claude/projects).
+    # Each entry gets its own launchd agent (Darwin) / systemd oneshot+timer
+    # (Linux), keyed by `name`. Uses the same fail-closed deny-set as the daemon.
+    extraReconcileRoots = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          name = mkOption {
+            type = types.str;
+            description = ''
+              Stable unit suffix (launchd Label / systemd unit name).
+              Use a short slug, e.g. "claude-projects".
+            '';
+            example = "claude-projects";
+          };
+          path = mkOption {
+            type = types.str;
+            description = "Absolute local directory to reconcile (the disjoint tree).";
+            example = "/Users/jess/.claude/projects";
+          };
+          prefix = mkOption {
+            type = types.str;
+            description = ''
+              Shared remote prefix within the bucket. This is the convergence
+              knob — every host using the SAME prefix converges on it.
+            '';
+            example = "agent/claude-projects";
+          };
+          intervalSec = mkOption {
+            type = types.int;
+            default = 300;
+            description = "Seconds between reconcile cycles (cadence).";
+          };
+          assumeFreshPrefix = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Export TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1 for the FIRST bulk push of
+              a known-empty prefix (skips redundant remote HEADs). Flip back to
+              false once the prefix has data, so deletes/overwrites stay correct.
+            '';
+          };
+        };
+      });
+      default = [];
+      description = ''
+        Disjoint trees to enroll via a scheduled `tcfs reconcile --execute` unit.
+        These are NOT the daemon sync_root and NOT FileProvider-gated; they run
+        from the CLI with the same engine + fail-closed security deny-set.
+      '';
+      example = [
+        { name = "claude-projects";
+          path = "/Users/jess/.claude/projects";
+          prefix = "agent/claude-projects";
+          intervalSec = 300; }
+      ];
+    };
+```
+
+### 1b. The `tcfsReconcileScript` builder + per-root state isolation
+
+Add to the top-level `let … in` block (e.g. directly after `mountWrapper`
+ends, around `tummycrypt.nix:338`). It sources credentials **exactly** like
+`daemonWrapper`/`mountWrapper` (hm-session-vars + `*_FILE` → `AWS_*`), guards on
+the daemon socket, and isolates each root's sync state under
+`$XDG_STATE_HOME/tcfsd/reconcile/<name>.json` so the disjoint tree never shares
+state with the primary `sync_root`.
+
+```nix
+  # Build a credential-sourcing reconcile runner for one extraReconcileRoots entry.
+  # Mirrors daemonWrapper/mountWrapper: source hm-session-vars, export AWS_* from
+  # the sops-nix *_FILE paths, guard on the daemon socket, then exec the CLI.
+  tcfsReconcileScript = root:
+    pkgs.writeShellScript "tcfsd-reconcile-${root.name}" ''
+      set -u
+
+      # Source home-manager session vars (contains *_FILE env vars from sops-nix)
+      HM_VARS="${config.home.profileDirectory}/etc/profile.d/hm-session-vars.sh"
+      if [ -f "$HM_VARS" ]; then
+        . "$HM_VARS"
+      fi
+
+      export TCFS_CONFIG="${config.xdg.configHome}/tcfs/config.toml"
+
+      # Export S3 credentials from sops-nix *_FILE env vars (same as daemonWrapper)
+      if [ -n "''${TCFS_S3_ACCESS_KEY_FILE:-}" ] && [ -f "''${TCFS_S3_ACCESS_KEY_FILE}" ]; then
+        export AWS_ACCESS_KEY_ID="$(cat "$TCFS_S3_ACCESS_KEY_FILE")"
+      fi
+      if [ -n "''${TCFS_S3_SECRET_KEY_FILE:-}" ] && [ -f "''${TCFS_S3_SECRET_KEY_FILE}" ]; then
+        export AWS_SECRET_ACCESS_KEY="$(cat "$TCFS_S3_SECRET_KEY_FILE")"
+      fi
+
+      # First-bulk-push helper: skip redundant remote HEADs on a fresh prefix.
+      ${lib.optionalString root.assumeFreshPrefix ''export TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1''}
+
+      # Guard: the daemon must be up so the master key / encryption session is
+      # available. If the socket is absent, exit 0 (the next cycle retries).
+      if [ ! -S "${socketPath}" ]; then
+        echo "$(date -Iseconds) tcfsd-reconcile-${root.name}: daemon socket ${socketPath} absent, skipping"
+        exit 0
+      fi
+
+      # Skip cleanly if the source tree does not exist yet on this host.
+      if [ ! -d "${root.path}" ]; then
+        echo "$(date -Iseconds) tcfsd-reconcile-${root.name}: ${root.path} not present, skipping"
+        exit 0
+      fi
+
+      # Per-root state isolation: never share sync state with the primary sync_root.
+      RECONCILE_STATE="${config.xdg.stateHome}/tcfsd/reconcile/${root.name}.json"
+      mkdir -p "$(dirname "$RECONCILE_STATE")" 2>/dev/null || true
+
+      echo "$(date -Iseconds) tcfsd-reconcile-${root.name}: reconciling ${root.path} -> ${root.prefix}"
+      exec ${tcfsCliBin} reconcile \
+        --path "${root.path}" \
+        --prefix "${root.prefix}" \
+        --state "$RECONCILE_STATE" \
+        --execute
+    '';
+```
+
+### 1c. The scheduled units — Darwin launchd agent + Linux systemd oneshot+timer
+
+Add these two config blocks to the `mkMerge [ … ]` list in `config`
+(e.g. directly after the existing Darwin/Linux health-check blocks, around
+`tummycrypt.nix:1341`). They follow the module's established health/reaper unit
+shape exactly: Darwin `launchd.agents.<label>` with `StartInterval` + log paths;
+Linux `systemd.user.services` (oneshot) + `systemd.user.timers`
+(`OnBootSec` + `OnUnitActiveSec`).
+
+```nix
+    # =========================================================================
+    # Darwin: scheduled reconcile agents for extraReconcileRoots (Track A)
+    # =========================================================================
+    (mkIf (isDarwin && cfg.daemon.enable && cfg.extraReconcileRoots != []) {
+      launchd.agents = lib.listToAttrs (map (root:
+        lib.nameValuePair "tcfsd-reconcile-${root.name}" {
+          enable = true;
+          config = {
+            Label = "dev.tinyland.tcfsd-reconcile-${root.name}";
+            ProgramArguments = [ "${tcfsReconcileScript root}" ];
+            StartInterval = root.intervalSec;
+            RunAtLoad = false;
+            ProcessType = "Background";
+            LowPriorityIO = true;
+            Nice = 10;
+            StandardOutPath = "${homeDir}/.local/state/log/tcfsd-reconcile-${root.name}.log";
+            StandardErrorPath = "${homeDir}/.local/state/log/tcfsd-reconcile-${root.name}.err";
+          };
+        }
+      ) cfg.extraReconcileRoots);
+    })
+
+    # =========================================================================
+    # Linux: scheduled reconcile oneshot + timer for extraReconcileRoots (Track A)
+    # =========================================================================
+    (mkIf (isLinux && cfg.daemon.enable && cfg.extraReconcileRoots != []) {
+      systemd.user.services = lib.listToAttrs (map (root:
+        lib.nameValuePair "tcfsd-reconcile-${root.name}" {
+          Unit = {
+            Description = "TummyCrypt scheduled reconcile (${root.name} -> ${root.prefix})";
+            After = [ "tcfsd.service" ];
+            Wants = [ "tcfsd.service" ];
+          };
+          Service = {
+            Type = "oneshot";
+            ExecStart = "${tcfsReconcileScript root}";
+            Environment = [
+              "PATH=/usr/bin:/bin:${lib.makeBinPath [ pkgs.coreutils ]}:${config.home.profileDirectory}/bin"
+              "TCFS_CONFIG_DIR=${config.xdg.configHome}/tcfs"
+            ];
+          };
+        }
+      ) cfg.extraReconcileRoots);
+
+      systemd.user.timers = lib.listToAttrs (map (root:
+        lib.nameValuePair "tcfsd-reconcile-${root.name}" {
+          Unit.Description = "TummyCrypt reconcile timer (${root.name})";
+          Timer = {
+            OnBootSec = "3m";
+            OnUnitActiveSec = "${toString root.intervalSec}s";
+            Persistent = true;
+          };
+          Install.WantedBy = [ "timers.target" ];
+        }
+      ) cfg.extraReconcileRoots);
+    })
+```
+
+> Notes:
+> - The Linux systemd `Service` writes its stdout/stderr to the journal
+>   (`journalctl --user -u tcfsd-reconcile-claude-projects`), matching the
+>   existing `tcfsd-health` / `tcfs-mcp-reaper` units which also rely on the
+>   journal rather than explicit log files.
+> - On Darwin, `RunAtLoad = false` keeps the first reconcile off the
+>   login-storm path; the first cycle fires `StartInterval` seconds after load.
+
+---
+
+## 2. Per-host enablement snippets
+
+### 2a. `nix/hosts/macbook-neo.nix`
+
+Add near the other `tinyland.tummycrypt.*` lines (e.g. after the
+`selectiveSync.dotfiles` block, ~line 58). neo already runs the daemon
+(`tummycrypt.enable = true`, FileProvider on) and has the master key unlocked,
+so the reconcile inherits the unlocked encryption session.
+
+```nix
+  # Track A: roam-enroll ~/.claude/projects onto the shared agent prefix.
+  # Disjoint tree (733 MB append-only JSONL) reconciled out-of-band from the
+  # single sync_root. BOUNDED-SUBSET FIRST: see step 3 before widening to the
+  # full tree. Flip assumeFreshPrefix=true ONLY for the first bulk push.
+  tinyland.tummycrypt.extraReconcileRoots = [
+    {
+      name = "claude-projects";
+      path = "/Users/jess/.claude/projects";
+      prefix = "agent/claude-projects";
+      intervalSec = 300;          # ~5 min cadence
+      assumeFreshPrefix = false;  # true ONLY for the very first bulk push
+    }
+  ];
+```
+
+### 2b. `nix/hosts/honey.nix`
+
+Add near the other `tinyland.tummycrypt.*` lines (e.g. after
+`secrets.enable = false;`, ~line 32). honey is Linux, runs the daemon, has no
+FileProvider — the scheduled reconcile runs regardless. Path is the Linux home.
+
+```nix
+  # Track A: roam-enroll ~/.claude/projects onto the shared agent prefix.
+  # Same convergence prefix as macbook-neo (agent/claude-projects) so the two
+  # hosts converge. honey has no FileProvider; reconcile is not FP-gated.
+  tinyland.tummycrypt.extraReconcileRoots = [
+    {
+      name = "claude-projects";
+      path = "/home/jess/.claude/projects";
+      prefix = "agent/claude-projects";
+      intervalSec = 300;          # ~5 min cadence
+      assumeFreshPrefix = false;  # true ONLY for the very first bulk push
+    }
+  ];
+```
+
+---
+
+## 3. Bounded-subset first step, then widen
+
+The first full 733 MB push is **serial** because crypto gates off the parallel
+fast path (`engine.rs:182`), so a cold full push is ~10-30 min. De-risk by
+proving the wiring on **one project subdir** before enrolling the whole tree.
+
+1. **Bounded subset.** On BOTH hosts, temporarily point `path` at a single
+   project subdir (pick a small one, same prefix on both hosts):
+
+   ```nix
+   # macbook-neo.nix  (temporary, bounded subset)
+   { name = "claude-projects";
+     path = "/Users/jess/.claude/projects/<one-small-project-dir>";
+     prefix = "agent/claude-projects";
+     intervalSec = 300;
+     assumeFreshPrefix = true; }   # first push of a fresh prefix
+   ```
+   ```nix
+   # honey.nix  (temporary, bounded subset — same prefix)
+   { name = "claude-projects";
+     path = "/home/jess/.claude/projects/<one-small-project-dir>";
+     prefix = "agent/claude-projects";
+     intervalSec = 300;
+     assumeFreshPrefix = true; }
+   ```
+
+   Apply on neo first; let it push. Then apply on honey; it should **pull** what
+   neo pushed. Prove neo<->honey convergence on the subset (see §4).
+
+2. **First bulk push of the full tree.** Once the subset converges, widen `path`
+   back to the full `~/.claude/projects` and keep `assumeFreshPrefix = true` for
+   the **single** initial bulk cycle on the host that holds the authoritative
+   copy. `TCFS_UPLOAD_ASSUME_FRESH_PREFIX=1` only skips redundant remote HEADs on
+   the known-empty prefix; per-file upload concurrency stays 1 under crypto, so
+   budget ~10-30 min for the 733 MB push. Watch the unit log until `Done: N
+   pushed`.
+
+3. **Steady state.** Flip `assumeFreshPrefix = false` on **all** hosts (so
+   subsequent cycles correctly HEAD the prefix and can reconcile deletes /
+   overwrites). Keep `intervalSec = 300` (~5 min). The append-only JSONL shape
+   means steady-state cycles are small incremental pushes.
+
+> Reality check: ~733 MB, append-only, 0 symlinks, no `.git` — well-suited to a
+> periodic reconcile. The deny-set still applies, so any stray secret-shaped file
+> under the tree is fail-closed excluded (see §4).
+
+---
+
+## 4. Verification
+
+Per cycle, the unit log (Darwin: `~/.local/state/log/tcfsd-reconcile-claude-projects.log`;
+Linux: `journalctl --user -u tcfsd-reconcile-claude-projects`) shows the engine's
+own lines (exact, from `tcfs-cli/src/main.rs`):
+
+```
+Reconciling /Users/jess/.claude/projects ↔ http://…:8333:agent/claude-projects/
+Plan: 12 push, 0 pull, 3 create-dir, 0 delete-local, 0 delete-remote, 0 conflict, 41 up-to-date
+Executing plan...
+  → push  <project>/<session>.jsonl  (LocalNewer)
+Done: 12 pushed, 0 pulled, 3 dirs-created, 0 deleted, 0 conflicts, 0 errors
+```
+
+**Checks:**
+
+1. **Per-cycle plan lines.** Confirm `Plan: N push …` then `Done: N pushed …` on
+   the authoritative host; on the other host confirm `N pull` then `N pulled`.
+   When both hosts are converged: `Plan: 0 push, 0 pull, …` and
+   `Nothing to do — local and remote are in sync.`
+
+2. **Deny-set is fail-closed.** Any secret/credential/live-DB-shaped file under
+   the tree never appears in a `→ push` line — it is filtered before the plan is
+   built (`Blacklist::from_sync_config` → `collect_local_set`, `reconcile.rs:525`).
+   Grep the unit log: no `auth.json`, `.credentials.json`, `*.sqlite`, `.env`
+   should ever be in a push line. (For `~/.claude/projects` specifically: it is
+   pure JSONL with no creds, but the deny-set is the safety net.)
+
+3. **SHA256-after-decrypt convergence on the shared prefix.** Pick a file present
+   on both hosts after a full cycle and compare plaintext hashes:
+
+   ```sh
+   # neo
+   shasum -a 256 ~/.claude/projects/<proj>/<session>.jsonl
+   # honey (after its reconcile pulls the same object)
+   sha256sum /home/jess/.claude/projects/<proj>/<session>.jsonl
+   ```
+
+   Equal digests prove the master-wrapped round-trip (encrypt-on-push /
+   decrypt-on-pull) preserved bytes across the shared `agent/claude-projects`
+   prefix. Because wrap_mode stays `master` (default), the wrap shape is
+   byte-identical to the existing `data` prefix.
+
+4. **Daemon-socket guard.** If the daemon is down, the unit logs
+   `daemon socket … absent, skipping` and exits 0 — no partial/failed push, the
+   next cycle retries.
+
+---
+
+## 5. Operator-apply steps (explicit)
+
+> These edits land in **`~/git/lab`** (NOT this repo). This document is the spec;
+> the operator applies it.
+
+1. **Edit `nix/home-manager/tummycrypt.nix`:**
+   - Paste §1a (the `extraReconcileRoots` option) into
+     `options.tinyland.tummycrypt`.
+   - Paste §1b (the `tcfsReconcileScript` builder) into the top-level `let`.
+   - Paste §1c (the Darwin launchd block + Linux systemd block) into the
+     `config` `mkMerge` list.
+2. **Edit `nix/hosts/macbook-neo.nix`:** paste §2a.
+3. **Edit `nix/hosts/honey.nix`:** paste §2b.
+4. **Bounded-subset first (§3 step 1):** set both hosts' `path` to one small
+   project subdir and `assumeFreshPrefix = true`, then switch:
+   ```sh
+   just nix-switch macbook-neo
+   just nix-switch honey
+   ```
+   Verify neo<->honey convergence on the subset (§4).
+5. **Widen + first bulk push (§3 step 2):** set `path` back to the full
+   `~/.claude/projects`, keep `assumeFreshPrefix = true` on the authoritative
+   host for the single bulk cycle, switch that host, watch the unit log to
+   `Done: N pushed`.
+6. **Steady state (§3 step 3):** set `assumeFreshPrefix = false` on all hosts,
+   `just nix-switch macbook-neo` and `just nix-switch honey`. Confirm ~5-min
+   cycles report `Nothing to do` once converged.
+
+**Rollback:** remove the `tinyland.tummycrypt.extraReconcileRoots` entry from the
+host file and `just nix-switch <host>`; home-manager tears down the launchd agent
+/ systemd timer. The remote `agent/claude-projects` prefix is independent of the
+`data` prefix and can be left in place or pruned separately.

--- a/docs/ops/git-repo-canary-dogfood.md
+++ b/docs/ops/git-repo-canary-dogfood.md
@@ -261,3 +261,9 @@ A live repo can become a candidate only after a shadow packet proves all of:
    that repo into TCFS.
 9. source symlinks are not skipped during push and rehydrate as symlinks with
    exact matching targets
+
+The broader "machine does not matter" claim has an additional acceptance matrix:
+[git-roam-daily-driver-acceptance-2026-06-08.md](git-roam-daily-driver-acceptance-2026-06-08.md).
+That matrix must pass for dirty WIP, Git metadata, agent context, unsync,
+conflict behavior, and reverse-origin flow before citing any repo canary as
+daily-driver `~/git` readiness.

--- a/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
+++ b/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
@@ -1,0 +1,238 @@
+# `~/git` Roam Daily-Driver Acceptance - 2026-06-08
+
+Status: acceptance plan for the "machine does not matter" TCFS user story.
+
+Related trackers: `TIN-1617`, `TIN-1620`, `TIN-1738`, `TIN-1899`.
+
+Related runbooks:
+
+- [large-workdir-daily-driver-sequencing-2026-05-30.md](large-workdir-daily-driver-sequencing-2026-05-30.md)
+- [claude-projects-roam-enrollment-2026-06-08.md](claude-projects-roam-enrollment-2026-06-08.md)
+- [git-repo-canary-dogfood.md](git-repo-canary-dogfood.md)
+
+## Golden Objective
+
+An enrolled operator can start work on any enrolled host, leave that work
+uncommitted, SSH into another enrolled host, browse the same logical `~/git`
+namespace, hydrate the needed repo and agent context, continue work, then
+optionally unsync either host without losing the remote encrypted copy.
+
+The claim is not "every byte under `~/git` is blindly mirrored." The claim is:
+
+1. enrolled repo roots are discoverable from every enrolled host;
+2. active working-tree state can be continued from any enrolled host;
+3. the Git history/refs needed to understand that work are restored by the
+   Git-safety path, not by naive live `.git/objects` mirroring;
+4. agent context for the same work is present through the `~/.claude/projects`
+   reconcile root; and
+5. secrets, live databases, caches, generated outputs, and large disposable
+   artifacts stay denied or snapshot-only.
+
+## What Must Be True
+
+The daily-driver story is only proven when all of these hold together for the
+same repo/session pair:
+
+- **Any origin host:** work can begin on `neo`, `honey`, or the next enrolled
+  host such as `bumble`.
+- **Any continuation host:** another enrolled host can traverse the repo path
+  before full hydration, hydrate only what is needed, and continue.
+- **Dirty WIP:** modified tracked files, untracked files, deletes, renames, file
+  mode changes, and symlink targets survive the round trip.
+- **Git metadata:** `git status --porcelain=v1 -b`, `git rev-parse HEAD`,
+  current branch, local refs, and the restored object graph match the source
+  snapshot after the Git bundle restore path runs.
+- **Agent continuity:** the matching `~/.claude/projects` session/subtree
+  converges with the repo so an agent can resume with the same transcript and
+  path references.
+- **Unsync/cloud-only:** either host can evict local bodies while preserving
+  stubs/metadata, and a later open or explicit hydrate restores exact bytes.
+- **Conflict visibility:** concurrent edits to the same file produce an
+  explicit conflict/recovery state, while independent sibling edits converge.
+- **Policy safety:** denied paths never enter a push plan, evidence packet, or
+  remote prefix.
+
+## Enrollment Model
+
+Use repo-by-repo enrollment. Do not flip broad `~/git` ownership as the first
+move.
+
+Recommended root classes:
+
+| Class | Default posture | Notes |
+| --- | --- | --- |
+| Working tree files | Sync | Normal source files, docs, tests, configs. |
+| `.git` | Git-safety bundle/restore | Restore real history and refs; do not rely on naive live object mirroring. |
+| Agent context | Scheduled reconcile | `~/.claude/projects` under `agent/claude-projects`; keep auth roots out. |
+| Generated output | Deny | `target`, `node_modules`, `.svelte-kit`, `build`, `.venv`, caches. |
+| Secrets/auth | Deny fail-closed | `.env*`, `auth.json`, `.credentials.json`, SOPS secret trees, SSH/GPG material. |
+| Live DB/WAL | Deny or snapshot-only | `*.sqlite`, `*.db`, `*-wal`, `*-shm`; never live-mirror open WAL streams. |
+| Large artifacts | Repo-specific | Example: `rockies/.artifacts` needs explicit policy. |
+
+## Acceptance Gates
+
+### R0 - Policy And Inventory
+
+For each candidate repo, archive:
+
+- root path, machine, hostname, timestamp, TCFS version, wrap mode, device list;
+- `git status --porcelain=v1 -b`;
+- `git rev-parse HEAD`, current branch, local refs summary;
+- untracked file inventory;
+- symlink inventory and targets;
+- unsupported special files;
+- generated-output and secret deny matches; and
+- expected remote prefix.
+
+Pass condition: denied paths are listed as denied, not silently omitted from the
+evidence.
+
+### R1 - Single-Origin Dirty WIP
+
+Start on `neo` with one small candidate repo and create a dirty snapshot:
+
+- modify a tracked source file;
+- add one untracked file;
+- delete one tracked file;
+- rename one file;
+- include one symlink or mode-change fixture when the repo supports it; and
+- append to the matching `~/.claude/projects` session.
+
+Pass condition: `honey` hydrates the repo and agent session, then reports the
+same dirty state and exact plaintext hashes.
+
+### R2 - Reverse Origin
+
+Repeat R1 with the mutation originating on `honey` and continuing on `neo`.
+
+Pass condition: the direction does not matter. This is the minimum proof for
+"work can start anywhere" across two hosts.
+
+### R3 - Unsync And Cloud-Only
+
+After R1/R2 converge:
+
+- unsync the source host;
+- verify local bodies are evicted while stubs/metadata remain where applicable;
+- hydrate on the continuation host;
+- reopen on the source host and rehydrate exact bytes.
+
+Pass condition: unsync is a local storage decision, not a data-loss event.
+
+### R4 - Git Bundle Restore
+
+Restore the repo into a fresh tree on the continuation host using the Git-safety
+bundle path.
+
+Pass condition:
+
+- `git fsck` passes where practical;
+- `git status --porcelain=v1 -b` matches the source snapshot;
+- `git rev-parse HEAD` matches;
+- local refs/branches needed by the WIP are present; and
+- the working tree and untracked files match the source evidence.
+
+### R5 - Conflict And Independent Edits
+
+Run both cases:
+
+- same-file concurrent edit on two hosts; and
+- independent sibling edits on two hosts.
+
+Pass condition: same-file conflict is explicit and recoverable; independent
+sibling edits converge without manual object surgery.
+
+### R6 - Third-Host Readiness
+
+Before claiming `bumble` or any new server:
+
+- enroll the device through the hardened enrollment path;
+- prove the same remote prefix and device registry converge;
+- run R1/R3 from `bumble` as origin or continuation; and
+- confirm no host-specific absolute paths are baked into repo state except
+  expected local config.
+
+Pass condition: the test matrix expands by adding one host row, not by writing a
+new special-case flow.
+
+## Candidate Repo Order
+
+Start with repos that expose the behavior without turning scale into the first
+failure mode:
+
+1. `ci-templates` - small operational repo, good first repo.
+2. `site.scaffold` - useful generated-output excludes (`node_modules`,
+   `.svelte-kit`, `build`).
+3. `dell-7810` - already useful in the bounded agent-session proof.
+4. `yt-text` / Tubebrain checkout - Rust target-dir exclude coverage.
+5. `xoxdwm` - review secret-feature fixture names before enrollment.
+6. `rockies` - only after `.artifacts` policy is explicit.
+7. `linux-xr` / `linux-xr-fast` - stress/WIP gate, not first daily-driver repo.
+
+## Evidence Packet Contract
+
+Every live repo-roam packet should contain:
+
+- `source.env`: origin host, continuation host, repo path, remote prefix, TCFS
+  binary path/version/hash, wrap mode, device ids.
+- `git-source.txt` and `git-continuation.txt`: status, branch, HEAD, refs
+  summary, and `git fsck` result when run.
+- `tree-source.sha256` and `tree-continuation.sha256`: plaintext file hashes
+  after applying the deny policy.
+- `agent-source.sha256` and `agent-continuation.sha256`: matching
+  `~/.claude/projects` session/subtree hashes.
+- `policy-deny.txt`: denied candidates observed during inventory.
+- `unsync.log`: local eviction / rehydrate transcript.
+- `conflict.log`: conflict or independent-edit transcript when that gate runs.
+- `result.env`: one machine-readable status with the allowed claim boundary.
+
+The packet must name whether it proves shadow-only, live repo, two-host, or
+three-host behavior. A packet that proves only shadow restore must not be cited
+as broad live `~/git` readiness.
+
+## Harness Gap List
+
+Existing helpers already cover important pieces:
+
+- `task lazy:git-roam-daily-driver-plan`
+- `task lazy:git-repo-canary`
+- `task lazy:git-repo-restore-proof`
+- `task lazy:neo-honey-unsynced-rehydrate-plan`
+- `task lazy:neo-honey-reverse-unsynced-rehydrate-plan`
+- `task lazy:neo-honey-delete-rename-unsynced-plan`
+- `task lazy:neo-honey-conflict-plan`
+
+Missing combined harnesses before the golden objective can be claimed:
+
+1. `git-roam-dirty-wip` - upgrades the plan-only packet into an executed R1
+   dirty snapshot and asserts exact
+   continuation state.
+2. `git-roam-reverse-origin` - same test with `honey` as origin.
+3. `git-roam-agent-coupled` - ties repo evidence to the matching
+   `~/.claude/projects` session evidence.
+4. `git-roam-third-host` - parameterizes the host matrix so `bumble` is another
+   row, not a new script family.
+5. `git-roam-policy-leak` - fails if any denied secret/live-DB/generated path
+   appears in push plans, evidence manifests, or remote listing samples.
+
+## Stop Rules
+
+- Do not bulk-enroll all of `~/git` before two small repos pass R0-R5 in both
+  directions.
+- Do not treat `~/.claude/projects` roam as proof that repo WIP roams; it only
+  proves agent context.
+- Do not treat Git shadow restore as proof that a live repo can be managed until
+  dirty WIP, unsync, and conflict gates pass.
+- Do not claim per-device revoke/rotate field security until the live fleet is
+  in `PerDevice` wrap mode and the revoked-device canary proves denial after
+  `tcfs key rotate <prefix>`.
+- Do not enroll live SQLite/WAL, auth files, `.env*`, SSH/GPG material, or SOPS
+  secret trees.
+
+## Next Implementation Slice
+
+The next low-risk code slice is a plan-only harness that emits the R0-R5 packet
+shape for one selected repo without mutating TCFS state. After that, wire
+execution to the existing `git-repo-canary`, reverse-origin, delete/rename,
+conflict, and restore-proof helpers so the combined user story is tested as one
+claim instead of five unrelated proofs.

--- a/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
+++ b/docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md
@@ -69,6 +69,20 @@ Recommended root classes:
 | Live DB/WAL | Deny or snapshot-only | `*.sqlite`, `*.db`, `*-wal`, `*-shm`; never live-mirror open WAL streams. |
 | Large artifacts | Repo-specific | Example: `rockies/.artifacts` needs explicit policy. |
 
+### Git Metadata Mode Boundary
+
+`sync_git_dirs` is currently a global `sync` config field consumed by
+`tcfs reconcile` through `Blacklist::from_sync_config`, not a per-root
+`extraReconcileRoots` knob. The default Git mode is `bundle`: raw `.git`
+internals are skipped, a `.git-tcfs-bundle` object is synced, and pull-side
+restore reconstructs Git history/refs from that bundle.
+
+Raw `.git` as ordinary files (`git_sync_mode = "raw"`) is a separate stress
+mode. It may become useful for exact index/stash/worktree experiments, but it
+is not the default daily-driver claim and must prove index/mtime, lockfile,
+symlink, mode, and concurrent-operation safety before it can replace the
+bundle/restore path.
+
 ## Acceptance Gates
 
 ### R0 - Policy And Inventory
@@ -203,6 +217,11 @@ Existing helpers already cover important pieces:
 - `task lazy:neo-honey-conflict-plan`
 
 Missing combined harnesses before the golden objective can be claimed:
+
+The plan-only harness bounds hash collection by default so a real agent
+transcript tree cannot become an accidental long-running scan. Use
+`MAX_HASH_FILES=0 MAX_HASH_FILE_BYTES=0` only when the live canary intentionally
+needs full plaintext hash manifests.
 
 1. `git-roam-dirty-wip` - upgrades the plan-only packet into an executed R1
    dirty snapshot and asserts exact

--- a/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
+++ b/docs/ops/large-workdir-daily-driver-sequencing-2026-05-30.md
@@ -181,3 +181,4 @@ Inherits the global stop rules from the productionization todo, plus:
 - `TIN-1620` one expendable live repo (G5) · `TIN-1546`/`TIN-1622` storage soak
 - Design seed: [large-workdir-onboarding-design-2026-05-25.md](large-workdir-onboarding-design-2026-05-25.md)
 - Execution checklist: [tcfs-daily-driver-productionization-todo-2026-05-24.md](tcfs-daily-driver-productionization-todo-2026-05-24.md)
+- `~/git` daily-driver acceptance: [git-roam-daily-driver-acceptance-2026-06-08.md](git-roam-daily-driver-acceptance-2026-06-08.md)

--- a/docs/ops/per-device-crypto-migration-2026-06-06.md
+++ b/docs/ops/per-device-crypto-migration-2026-06-06.md
@@ -12,9 +12,48 @@ Date: 2026-06-06.
 Grounding: every primitive, phase, and revocation claim here derives from
 `docs/ops/per-device-crypto-identity-design-2026-05-18.md` (the "design doc"
 below). Where this plan adds operational structure not in the design doc — an
-expand/contract ordering, a `per_device_wrap_strict` gate, per-step rollback —
-it is called out as such and grounded in the verified code state on
+expand/contract ordering, the tri-state `crypto.wrap_mode` gate, per-step
+rollback — it is called out as such and grounded in the verified code state on
 `origin/main` as of this date.
+
+## The control surface: `crypto.wrap_mode` (tri-state)
+
+The migration is driven by a single tri-state config enum,
+`crypto.wrap_mode`, with three values. This REPLACES the earlier
+shipped-but-never-flipped `crypto.per_device_wrapping: bool` (v0.12.14, default
+false, set true NOWHERE live). The enum makes the expand/contract phases
+explicit and impossible to conflate:
+
+| `wrap_mode`  | Manifest carries                                  | Manifest version | Migration phase |
+|--------------|---------------------------------------------------|------------------|-----------------|
+| `master`     | `encrypted_file_key` only                         | v2               | baseline / default |
+| `dual`       | BOTH `encrypted_file_key` AND `wrapped_file_keys` | v2               | EXPAND / transitional |
+| `per_device` | `wrapped_file_keys` only (master wrap dropped)    | v3               | CONTRACT |
+
+Semantics, exactly:
+
+- **`master`** (DEFAULT) — today's master-only wrap. This MUST be byte-identical
+  to the prior `per_device_wrapping=false` behavior: the engine takes
+  `EncryptionContext::new(master_key)` and the legacy single-wrap path,
+  unchanged. Manifests stay v2.
+- **`dual`** (EXPAND) — every writer emits BOTH the legacy master wrap
+  (`encrypted_file_key`, for rollback + master/old-binary readers) AND the
+  per-device wraps (`wrapped_file_keys`). Any reader, upgraded or not, can
+  decrypt: an upgraded reader uses its per-device wrap; a master-only / legacy
+  reader falls back to the master wrap. Back-compatible by construction, so
+  manifests stay v2 (design doc Phase 1, line 207).
+- **`per_device`** (CONTRACT) — writers emit ONLY `wrapped_file_keys` and DROP
+  the master wrap, so a device removed from the recipient set (revoked) cannot
+  decrypt newly written content — true revocation. Because dropping the master
+  wrap changes what an old reader sees, per-device manifests are bumped to
+  **manifest version 3** so a pre-per-device binary fails CLOSED instead of
+  misreading a v2-with-no-`encrypted_file_key` as keyless (design doc Phase 2/3,
+  lines 212–219).
+
+Going forward `wrap_mode` is canonical. For back-compat the deserializer still
+accepts a legacy `per_device_wrapping` field and maps it: `true` -> `dual`
+(safe — keeps the master fallback, never silently drops it), `false`/absent ->
+`master`. When both keys are present, `wrap_mode` wins.
 
 ## Why expand/contract
 
@@ -23,27 +62,48 @@ through Phase 4 as a schema evolution. This plan re-expresses that as a strict
 **expand-then-contract** discipline so that at no point is there a fleet state
 where a healthy, non-revoked device cannot read content it is entitled to read:
 
-- **Expand**: every writer emits BOTH the legacy master wrap
-  (`encrypted_file_key`) and the per-device wraps (`wrapped_file_keys`) — dual
-  write. Any reader, upgraded or not, can decrypt. This is design doc Phase 1
-  (line 207).
-- **Contract**: only after a green fleet roll-call do writers stop emitting the
-  legacy master wrap, per manifest, one direction. This is design doc Phase 2/3
-  (lines 212–219), gated behind a new `per_device_wrap_strict` flag this plan
-  introduces.
+- **Expand** = `wrap_mode = dual`: every writer emits BOTH wraps. Any reader,
+  upgraded or not, can decrypt. This is design doc Phase 1 (line 207).
+- **Contract** = `wrap_mode = per_device`: only after a green fleet roll-call do
+  writers stop emitting the legacy master wrap, per manifest, one direction.
+  This is design doc Phase 2/3 (lines 212–219).
 
-The existing `crypto.per_device_wrapping` flag (default false, verified at
-`crates/tcfs-core/src/config.rs:337,351`) is the EXPAND switch: it makes writers
-ADD per-device wraps. It does not, by itself, remove the master wrap — and this
-plan requires that it never does. The CONTRACT switch is a separate, new
-`per_device_wrap_strict` flag (does not exist in tree yet — verified absent on
-`origin/main`) that gates dropping the master wrap. Splitting expand from
-contract is the core safety property of this migration.
+`dual` is the EXPAND switch: it makes writers ADD per-device wraps WITHOUT
+removing the master wrap. `per_device` is the CONTRACT switch: it is the only
+mode that drops the master wrap, and it is the only mode that writes v3
+manifests. Splitting expand (`dual`, v2) from contract (`per_device`, v3) is the
+core safety property of this migration.
 
-Default-off behavior MUST stay byte-identical: with `per_device_wrapping=false`
-the engine takes `EncryptionContext::new(master_key)` and the legacy single-wrap
-path unchanged (verified: daemon `build_encryption_context` returns `base` early
-when the flag is false, `crates/tcfsd/src/grpc.rs:39-42`).
+Default-off behavior MUST stay byte-identical: with `wrap_mode = master` (the
+default) the engine takes `EncryptionContext::new(master_key)` and the legacy
+single-wrap path unchanged (verified: daemon `build_encryption_context` returns
+`base` early when the mode is `master`, `crates/tcfsd/src/grpc.rs`).
+
+## The roll-call code gate (before `per_device`)
+
+Contracting to `per_device` drops the master wrap, which strands any active
+device that is NOT per-device-capable. This is a CODE gate, not a doc note: the
+daemon (and CLI, and FileProvider read path) REFUSES to operate in `per_device`
+until a roll-call probe confirms every active (non-revoked) device in the
+registry has a real, parseable age recipient
+(`tcfs_secrets::device::is_real_age_public_key`). Until that probe reads green,
+the requested `per_device` mode is DOWNGRADED to `dual` and a loud warning is
+emitted (`ROLL-CALL GATE: ... refusing to drop the master wrap. Falling back to
+DUAL ...`) listing the incapable device IDs. It never silently drops the master
+wrap.
+
+Verified surface: `DeviceRegistry::per_device_roll_call_ready()` returns true
+only when there is at least one active device AND every active device is
+per-device-capable; `per_device_incapable_active_devices()` enumerates the ones
+that are not. The daemon resolves the effective mode from the requested mode and
+this probe, and attaches it to the `EncryptionContext` via
+`.with_wrap_mode(...)`. The engine write path trusts that effective mode as
+authoritative and does not re-run the probe — so any caller that wants
+`per_device` but cannot prove fleet capability MUST have already downgraded to
+`dual`. There is also a structural safety floor: if a non-`master` mode is
+requested but there are zero per-device recipients (nobody to wrap for), the
+write path falls CLOSED to master-only v2 output rather than emitting a keyless
+or unreadable manifest.
 
 ## Migration Sequence
 
@@ -52,64 +112,63 @@ when the flag is false, `crates/tcfsd/src/grpc.rs:39-42`).
 Bring the FileProvider direct restore path to crypto parity with the daemon and
 CLI before any per-device wrapping is enabled anywhere on the fleet.
 
-Verified gap: `crates/tcfs-file-provider/src/grpc_backend.rs:232-234` builds
-`EncryptionContext::new(mk)` only — device identity is `None`, it never calls
-`.with_device_wrapping`. The engine read switch
-(`crates/tcfs-sync/src/engine.rs:2226-2236`) takes the `wrapped_file_keys`-
-non-empty branch FIRST and hard-fails ("manifest is per-device encrypted but
-this device has no age identity") with no master fallback. So the moment any
-per-device manifest reaches a FileProvider hydrate, hydration breaks. The daemon
-(`crates/tcfsd/src/grpc.rs:32-83`, gated on `crypto.per_device_wrapping` at :40,
-`.with_device_wrapping` at :82) and CLI (`crates/tcfs-cli/src/main.rs:1108-1158`)
-already wire device identity. The FileProvider crate has no
-`build_encryption_context` helper — Step 1 adds one, mirroring the daemon's
-fail-closed-to-master-readable logic.
+Verified gap (historical): the FileProvider direct read path built
+`EncryptionContext::new(mk)` only — device identity was `None`, it never called
+`.with_device_wrapping`. The engine read switch takes the `wrapped_file_keys`-
+non-empty branch and (for a v3 per-device-only manifest) hard-fails with no
+master fallback. So the moment any per-device-only manifest reached a
+FileProvider hydrate, hydration broke. PR #492 closed this by adding an
+FP-local `build_encryption_context` (`crates/tcfs-file-provider/src/device_ctx.rs`)
+mirroring the daemon's fail-closed-to-master-readable logic; this plan updates
+that helper to read `crypto.wrap_mode` (with legacy `per_device_wrapping`
+back-compat) and apply the same roll-call gate.
 
-Step 1 lands BEFORE the flag is enabled on any host, so it is a no-op while every
+Step 1 lands BEFORE any host moves off `master`, so it is a no-op while every
 manifest is still legacy single-wrap. It only matters once Step 3 puts
 per-device manifests on the wire.
 
-Note: the non-prod default/uniffi backends are worse than grpc_backend — they
-match only on `encrypted_file_key`, fall to `_ => None`, and copy chunks as raw
-ciphertext (silent corruption). Step 1 must either fix or explicitly fence these
-backends so a per-device manifest cannot reach them and corrupt silently.
+Note: the non-prod default/uniffi backends only implement master-key
+unwrapping. A per-device (`wrapped_file_keys`) manifest reaching them would copy
+chunks as raw ciphertext (silent corruption); `ensure_master_decryptable`
+(`device_ctx.rs`) fences these backends so a per-device manifest cannot reach
+them and corrupt silently — it bails with a clear error instead.
 
-### Step 2 — B3 restore Phase-1 dual-write + roll-call gate (expand)
+### Step 2 — B3 dual-write through every caller + roll-call gate (expand)
 
 Wire per-device dual-write through every restore caller and introduce the
-roll-call gate behind the new `per_device_wrap_strict` flag (default false).
+roll-call gate in the shared `build_encryption_context` helpers.
 
-Three verified production restore callers must all honor per-device unwrap with
-master fallback: `crates/tcfs-sync/src/reconcile.rs:906` and `:1068` (auto-roam
-Pull), `crates/tcfs-file-provider/src/grpc_backend.rs:236` (FileProvider, fixed
-in Step 1), and `crates/tcfs-cli/src/main.rs:1436` (CLI pull). Upload side:
-`upload_symlink_with_device` (`crates/tcfs-sync/src/engine.rs:1995`) and the
-single wrap call site referenced in the design doc (line 240).
+The production restore callers must all honor per-device unwrap with master
+fallback: auto-roam Pull (`crates/tcfs-sync/src/reconcile.rs`), the FileProvider
+read path (`crates/tcfs-file-provider/src/grpc_backend.rs`, fixed in Step 1), and
+CLI pull (`crates/tcfs-cli/src/main.rs`). Upload side: the single wrap call site
+in the engine write path (`crates/tcfs-sync/src/engine.rs`).
 
-In this step writers emit BOTH wraps (design doc Phase 1, line 207). The new
-`per_device_wrap_strict` flag is added but stays false; it only later (Step 7)
-authorizes dropping the master wrap. The roll-call probe (design doc line 216 —
-"gate the flag on a fleet roll-call probe that confirms every active device is
-on the new binary") is built here and must read green before Step 7.
+In this step writers can run `wrap_mode = dual` (design doc Phase 1, line 207):
+BOTH wraps emitted, v2. The roll-call probe (design doc line 216 — "gate the
+flag on a fleet roll-call probe that confirms every active device is on the new
+binary") is built here and must read green before Step 7. Crucially, the gate is
+already wired so that even if an operator sets `per_device` early, the daemon
+downgrades to `dual` until the roll-call is green — there is no unguarded path
+that drops the master wrap.
 
 ### Step 3 — Canary both directions including FileProvider hydrate (expand)
 
-Enable `crypto.per_device_wrapping=true` on a small canary subset (still
-dual-write, master wrap retained). Exercise push from canary, pull on canary,
-pull on a legacy peer, and — critically — FileProvider hydrate on macOS, which is
-the path Step 1 fixed and the one most likely to regress. Verify every direction
-decrypts. Because the master wrap is still present, a legacy or
-identity-missing reader still succeeds via fallback.
+Set `crypto.wrap_mode = dual` on a small canary subset (master wrap retained).
+Exercise push from canary, pull on canary, pull on a legacy peer, and —
+critically — FileProvider hydrate on macOS, which is the path Step 1 fixed and
+the one most likely to regress. Verify every direction decrypts. Because the
+master wrap is still present (dual is v2), a legacy or identity-missing reader
+still succeeds via the master fallback in the engine read switch.
 
 ### Step 4 — B4 sign devices.json (expand)
 
-Sign the device registry (`meta_prefix/tcfs-meta/devices.json`,
-`crates/tcfs-secrets/src/device.rs` load_remote at line 145) so that recipient
-sets and revocations cannot be forged by a peer. The design doc makes the S3
-registry the canonical revocation authority (design doc decision 3, lines 96–98)
-and requires that an unrelated device cannot mint a revocation record (design doc
-Tests, lines 264). Recipient-set integrity must be established before strict mode
-makes recipient-set membership the sole gate on readability.
+Sign the device registry (`meta_prefix/tcfs-meta/devices.json`) so that
+recipient sets and revocations cannot be forged by a peer. The design doc makes
+the S3 registry the canonical revocation authority (design doc decision 3, lines
+96–98) and requires that an unrelated device cannot mint a revocation record
+(design doc Tests, line 264). Recipient-set integrity must be established before
+`per_device` makes recipient-set membership the sole gate on readability.
 
 ### Step 5 — B2 per-device key rotation `tcfs key rotate <prefix>` (expand-capable)
 
@@ -119,8 +178,8 @@ fresh FileKeys, re-chunks and re-uploads under new BLAKE3 addresses, and
 republishes manifests wrapped only to the post-revocation recipient set. It is
 expensive (full re-push of the rotated set) and must surface projected
 bytes-to-rewrite before the operator confirms (design doc line 194). Landing it
-before the flag flip means revocation has a working remedy the day strict mode
-goes live.
+before the contract flip means revocation has a working remedy the day
+`per_device` goes live.
 
 ### Step 6 — Keychain hardening (expand)
 
@@ -128,20 +187,27 @@ Move device secret halves into the OS keychain (macOS Keychain, Linux
 secret-service / file-fallback, Windows DPAPI) per design doc lines 78–81 and
 decision 2 (lines 92–95). The Phase 0 `0600` file fallback
 (`device-<device_id>.age`) is acceptable for dev/test with an explicit
-insecure-mode marker but is not the production posture. Harden before strict mode
-so a lost-laptop revocation is meaningful at the secret-storage layer, not just
-the registry layer.
+insecure-mode marker but is not the production posture. Harden before the
+contract flip so a lost-laptop revocation is meaningful at the secret-storage
+layer, not just the registry layer.
 
-### Step 7 — Flag flip LAST: strict after green roll-call (contract)
+### Step 7 — Contract LAST: `per_device` after green roll-call (contract)
 
-Only now, after Steps 1–6 and a green roll-call, flip
-`per_device_wrap_strict=true` so writers stop emitting the legacy master wrap
-(design doc Phase 2/3, lines 212–219). The flip is gated on the roll-call probe
-confirming every active device is on a binary that can unwrap per-device
-manifests. The flip is one-way PER MANIFEST: a manifest written strict drops the
-master wrap on its next version only; already-dual-written manifests stay
-master-readable. Pull paths keep accepting both wraps indefinitely (design doc
-decision 7, lines 108–110, and Phase 3 line 217 — "keep the deserialiser").
+Only now, after Steps 1–6 and a green roll-call, set `crypto.wrap_mode =
+per_device` so writers stop emitting the legacy master wrap and start writing v3
+manifests (design doc Phase 2/3, lines 212–219). The roll-call code gate
+described above is the enforcement: if any active device is not
+per-device-capable, the daemon refuses to contract and stays on `dual` with a
+loud warning — the operator setting `per_device` is necessary but not sufficient.
+
+The contract is one-way PER MANIFEST: a manifest written `per_device` drops the
+master wrap and bumps to v3 on its next version only; already-dual-written (v2)
+manifests stay master-readable. Pull paths keep accepting all three shapes
+indefinitely — v2 master-only, v2 dual, and v3 per-device-only (design doc
+decision 7, lines 108–110, and Phase 3 line 217 — "keep the deserialiser"). The
+engine read switch additionally fails CLOSED on a regular-file manifest whose
+version exceeds the highest it understands (currently v3), so a future writer
+cannot trick an older reader into misinterpreting its schema.
 
 Master-key retirement (design doc Phase 4, lines 220–224) is explicitly OUT OF
 SCOPE for this migration and tracked as TIN-1417-followup.
@@ -150,26 +216,30 @@ SCOPE for this migration and tracked as TIN-1417-followup.
 
 The migration is reversible at every step because expand never removes a wrap:
 
-- **Steps 1–2 (code lands, flag off)**: revert the PR. No manifest on the wire
-  changed; default-off behavior was byte-identical throughout.
-- **Step 3 (canary, `per_device_wrapping=true`)**: set
-  `crypto.per_device_wrapping=false`. Writers revert to legacy single-wrap.
-  Every manifest written during the canary is dual-written and therefore stays
-  master-readable by every device — nothing is stranded.
+- **Steps 1–2 (code lands, mode stays `master`)**: revert the PR. No manifest on
+  the wire changed; default behavior was byte-identical throughout.
+- **Step 3 (canary, `wrap_mode = dual`)**: set `crypto.wrap_mode = master`.
+  Writers revert to legacy single-wrap. Every manifest written during the canary
+  is dual-written (v2, master wrap present) and therefore stays master-readable
+  by every device — nothing is stranded.
 - **Step 4 (signed registry)**: revert to unsigned; signing is additive
   verification, not a wrap change.
 - **Step 5 (rotation)**: rotation is operator-initiated and idempotent at the
   prefix level; do not run it, or roll forward only the prefixes you intend.
 - **Step 6 (keychain)**: file fallback remains the documented escape hatch.
-- **Step 7 (strict)**: flip `per_device_wrap_strict=false`. Writers resume
-  dual-write immediately. The one-way property is PER MANIFEST and only takes
-  effect after a green roll-call, so the blast radius of a bad flip is bounded to
-  manifests written while strict was on; those manifests are still readable by
-  every then-active recipient (that is the roll-call precondition). Dual-written
-  manifests from before the flip remain master-readable regardless.
+- **Step 7 (`per_device`)**: set `crypto.wrap_mode = dual` (or `master`).
+  Writers resume dual-write (or single-wrap) immediately. The contract is
+  one-way PER MANIFEST and only takes effect after a green roll-call, so the
+  blast radius of a bad flip is bounded to manifests written while `per_device`
+  was on; those manifests (v3) are still readable by every then-active recipient
+  (that is the roll-call precondition). Dual-written (v2) manifests from before
+  the flip remain master-readable regardless. Note: reverting to `dual`/`master`
+  does NOT rewrite the v3 manifests already on the wire — readers must still be
+  able to unwrap them per-device, which the roll-call guaranteed before the flip.
 
-Invariant: dual-written manifests stay master-readable; the strict (master-wrap-
-drop) transition is one-way per manifest and only after roll-call.
+Invariant: dual-written (v2) manifests stay master-readable; the contract
+(master-wrap-drop, v3) transition is one-way per manifest and only after
+roll-call.
 
 ## Honest Claim Boundary
 
@@ -178,12 +248,14 @@ from the design doc (Revocation Semantics, lines 164–195) and it does not chan
 under this plan:
 
 - A revoked device CANNOT decrypt manifests written after the revocation
-  propagates AND after those files are next rewritten/rekeyed.
+  propagates AND after those files are next rewritten/rekeyed in `per_device`
+  (v3) mode.
 - A revoked device CAN still decrypt anything it already pulled (it holds the
   FileKey forever — "there is no cryptographic time machine", design doc line
   180) and anything still carrying a wrap it can open.
-- Critically: content that is already-pulled, OR not-yet-rekeyed, stays
-  master-decryptable until `tcfs key rotate <prefix>` re-chunks and rewraps it.
+- Critically: content that is already-pulled, OR still carries a master wrap
+  (any v2 master/dual manifest), OR is not-yet-rekeyed, stays master-decryptable
+  until `tcfs key rotate <prefix>` re-chunks and rewraps it as `per_device` (v3).
   Revocation alone does NOT rewrite historical manifests (design doc lines
   151–162). Forward secrecy is a SEPARATE, explicit, expensive operator action.
 
@@ -206,17 +278,27 @@ until you run `tcfs key rotate`."
    (design doc decision 5); per-file deferred to TIN-1418.
 6. **Old PII in invites**: Treat plaintext-secret invites as a user-visible
    security correction with a CHANGELOG/security note (design doc decision 6).
-7. **Backward-compat window**: Keep v2 single-wrap reads indefinitely; stop
-   WRITING v2 only after the strict cutover gate (design doc decision 7).
+7. **Backward-compat window**: Keep v2 reads (master and dual) AND v3 reads
+   (per-device) indefinitely; stop WRITING the master wrap only after the
+   `per_device` contract gate (design doc decision 7).
 
 ## Residual Risks
 
 - **Manual / partial forward secrecy**: revocation is not forward-secret by
   itself; the operator must run `tcfs key rotate <prefix>` per affected prefix,
-  and any prefix not rotated stays master-decryptable to the revoked device.
+  and any prefix not rotated stays master-decryptable (it is still a v2
+  master/dual manifest) to the revoked device.
 - **Deferred NATS advisory leg**: sub-second revocation propagation is out of
   scope; the fleet accepts S3 eventual-consistency timing and must document the
   propagation window.
+- **Manifest version-3 namespace sharing**: regular-file per-device (v3)
+  manifests and symlink (v3) manifests both use `version: 3`. They are
+  disambiguated structurally — symlink manifests carry `kind: symlink` and are
+  dispatched first via `SymlinkManifest::from_bytes` (which requires both
+  `version == 3` and `kind == symlink`); a regular-file v3 manifest has no
+  `kind` field and falls through to `SyncManifest::from_bytes`. This is verified
+  but is a sharp edge: any future v3 regular-file schema change must preserve the
+  no-`kind` discriminator so the dispatch stays unambiguous.
 - **AES-SIV filename determinism**: deterministic filename encryption leaks
   equality/structure of names across the recipient set; per-device wrapping does
   not change this and it is not addressed here.
@@ -228,17 +310,13 @@ until you run `tcfs key rotate`."
   stays disabled until invites no longer carry raw long-lived credentials
   (design doc lines 116–119, 240–246).
 - **Symlink restore (PR-A)**: the restore path materializes a peer-published
-  symlink target verbatim — `create_local_symlink`
-  (`crates/tcfs-sync/src/engine.rs:2415-2441`) calls
-  `std::os::unix::fs::symlink(target)` at `:2427` with no deny-set, traversal, or
-  absolute-path guard, reached from `download_file_with_device`
-  (`engine.rs:2114`) via all three production restore callers. A hostile peer can
-  publish a `SymlinkManifest` targeting `../../.ssh/authorized_keys` and every
-  pulling host materializes it. Per-device wrapping does NOT mitigate this — a
-  legitimate-but-compromised or hostile recipient is still a valid recipient.
-  Tracked separately as PR-A and must be fixed independently of this migration.
+  symlink target. The merged symlink guard (#491) adds a deny-set / traversal /
+  absolute-path check in `create_local_symlink`; per-device wrapping does NOT by
+  itself mitigate a legitimate-but-compromised or hostile recipient, who is
+  still a valid recipient. Tracked separately and must be fixed independently of
+  this migration.
 
 ---
 
 This plan is the operator-facing sequencing for TIN-1417. Land alignment in PR
-comments. No flag flips and no fleet mutation occur from merging this doc.
+comments. No mode flips and no fleet mutation occur from merging this doc.

--- a/docs/ops/per-device-crypto-migration-2026-06-06.md
+++ b/docs/ops/per-device-crypto-migration-2026-06-06.md
@@ -1,0 +1,244 @@
+# Shared-Master to Per-Device Crypto Migration Plan (TIN-1417)
+
+Status: operational migration plan. Doc-only. No code lands with this document;
+no fleet config flips with this document. This is the verified, ratified
+sequencing the fleet follows to move from the shared-master-key model to
+per-device age/X25519 FileKey wrapping. It is an acceptance artifact for the
+TIN-1417 design (`docs/ops/per-device-crypto-identity-design-2026-05-18.md`) and
+should be read as the operator-facing companion to that design recon.
+
+Date: 2026-06-06.
+
+Grounding: every primitive, phase, and revocation claim here derives from
+`docs/ops/per-device-crypto-identity-design-2026-05-18.md` (the "design doc"
+below). Where this plan adds operational structure not in the design doc — an
+expand/contract ordering, a `per_device_wrap_strict` gate, per-step rollback —
+it is called out as such and grounded in the verified code state on
+`origin/main` as of this date.
+
+## Why expand/contract
+
+The design doc's Migration Path (design doc lines 198–224) lays out Phase 0
+through Phase 4 as a schema evolution. This plan re-expresses that as a strict
+**expand-then-contract** discipline so that at no point is there a fleet state
+where a healthy, non-revoked device cannot read content it is entitled to read:
+
+- **Expand**: every writer emits BOTH the legacy master wrap
+  (`encrypted_file_key`) and the per-device wraps (`wrapped_file_keys`) — dual
+  write. Any reader, upgraded or not, can decrypt. This is design doc Phase 1
+  (line 207).
+- **Contract**: only after a green fleet roll-call do writers stop emitting the
+  legacy master wrap, per manifest, one direction. This is design doc Phase 2/3
+  (lines 212–219), gated behind a new `per_device_wrap_strict` flag this plan
+  introduces.
+
+The existing `crypto.per_device_wrapping` flag (default false, verified at
+`crates/tcfs-core/src/config.rs:337,351`) is the EXPAND switch: it makes writers
+ADD per-device wraps. It does not, by itself, remove the master wrap — and this
+plan requires that it never does. The CONTRACT switch is a separate, new
+`per_device_wrap_strict` flag (does not exist in tree yet — verified absent on
+`origin/main`) that gates dropping the master wrap. Splitting expand from
+contract is the core safety property of this migration.
+
+Default-off behavior MUST stay byte-identical: with `per_device_wrapping=false`
+the engine takes `EncryptionContext::new(master_key)` and the legacy single-wrap
+path unchanged (verified: daemon `build_encryption_context` returns `base` early
+when the flag is false, `crates/tcfsd/src/grpc.rs:39-42`).
+
+## Migration Sequence
+
+### Step 1 — B1 FileProvider parity (expand, prerequisite)
+
+Bring the FileProvider direct restore path to crypto parity with the daemon and
+CLI before any per-device wrapping is enabled anywhere on the fleet.
+
+Verified gap: `crates/tcfs-file-provider/src/grpc_backend.rs:232-234` builds
+`EncryptionContext::new(mk)` only — device identity is `None`, it never calls
+`.with_device_wrapping`. The engine read switch
+(`crates/tcfs-sync/src/engine.rs:2226-2236`) takes the `wrapped_file_keys`-
+non-empty branch FIRST and hard-fails ("manifest is per-device encrypted but
+this device has no age identity") with no master fallback. So the moment any
+per-device manifest reaches a FileProvider hydrate, hydration breaks. The daemon
+(`crates/tcfsd/src/grpc.rs:32-83`, gated on `crypto.per_device_wrapping` at :40,
+`.with_device_wrapping` at :82) and CLI (`crates/tcfs-cli/src/main.rs:1108-1158`)
+already wire device identity. The FileProvider crate has no
+`build_encryption_context` helper — Step 1 adds one, mirroring the daemon's
+fail-closed-to-master-readable logic.
+
+Step 1 lands BEFORE the flag is enabled on any host, so it is a no-op while every
+manifest is still legacy single-wrap. It only matters once Step 3 puts
+per-device manifests on the wire.
+
+Note: the non-prod default/uniffi backends are worse than grpc_backend — they
+match only on `encrypted_file_key`, fall to `_ => None`, and copy chunks as raw
+ciphertext (silent corruption). Step 1 must either fix or explicitly fence these
+backends so a per-device manifest cannot reach them and corrupt silently.
+
+### Step 2 — B3 restore Phase-1 dual-write + roll-call gate (expand)
+
+Wire per-device dual-write through every restore caller and introduce the
+roll-call gate behind the new `per_device_wrap_strict` flag (default false).
+
+Three verified production restore callers must all honor per-device unwrap with
+master fallback: `crates/tcfs-sync/src/reconcile.rs:906` and `:1068` (auto-roam
+Pull), `crates/tcfs-file-provider/src/grpc_backend.rs:236` (FileProvider, fixed
+in Step 1), and `crates/tcfs-cli/src/main.rs:1436` (CLI pull). Upload side:
+`upload_symlink_with_device` (`crates/tcfs-sync/src/engine.rs:1995`) and the
+single wrap call site referenced in the design doc (line 240).
+
+In this step writers emit BOTH wraps (design doc Phase 1, line 207). The new
+`per_device_wrap_strict` flag is added but stays false; it only later (Step 7)
+authorizes dropping the master wrap. The roll-call probe (design doc line 216 —
+"gate the flag on a fleet roll-call probe that confirms every active device is
+on the new binary") is built here and must read green before Step 7.
+
+### Step 3 — Canary both directions including FileProvider hydrate (expand)
+
+Enable `crypto.per_device_wrapping=true` on a small canary subset (still
+dual-write, master wrap retained). Exercise push from canary, pull on canary,
+pull on a legacy peer, and — critically — FileProvider hydrate on macOS, which is
+the path Step 1 fixed and the one most likely to regress. Verify every direction
+decrypts. Because the master wrap is still present, a legacy or
+identity-missing reader still succeeds via fallback.
+
+### Step 4 — B4 sign devices.json (expand)
+
+Sign the device registry (`meta_prefix/tcfs-meta/devices.json`,
+`crates/tcfs-secrets/src/device.rs` load_remote at line 145) so that recipient
+sets and revocations cannot be forged by a peer. The design doc makes the S3
+registry the canonical revocation authority (design doc decision 3, lines 96–98)
+and requires that an unrelated device cannot mint a revocation record (design doc
+Tests, lines 264). Recipient-set integrity must be established before strict mode
+makes recipient-set membership the sole gate on readability.
+
+### Step 5 — B2 per-device key rotation `tcfs key rotate <prefix>` (expand-capable)
+
+Land the scoped rotation command (design doc lines 184–195, 250). This is the
+ONLY mechanism that delivers forward secrecy after a revocation: it generates
+fresh FileKeys, re-chunks and re-uploads under new BLAKE3 addresses, and
+republishes manifests wrapped only to the post-revocation recipient set. It is
+expensive (full re-push of the rotated set) and must surface projected
+bytes-to-rewrite before the operator confirms (design doc line 194). Landing it
+before the flag flip means revocation has a working remedy the day strict mode
+goes live.
+
+### Step 6 — Keychain hardening (expand)
+
+Move device secret halves into the OS keychain (macOS Keychain, Linux
+secret-service / file-fallback, Windows DPAPI) per design doc lines 78–81 and
+decision 2 (lines 92–95). The Phase 0 `0600` file fallback
+(`device-<device_id>.age`) is acceptable for dev/test with an explicit
+insecure-mode marker but is not the production posture. Harden before strict mode
+so a lost-laptop revocation is meaningful at the secret-storage layer, not just
+the registry layer.
+
+### Step 7 — Flag flip LAST: strict after green roll-call (contract)
+
+Only now, after Steps 1–6 and a green roll-call, flip
+`per_device_wrap_strict=true` so writers stop emitting the legacy master wrap
+(design doc Phase 2/3, lines 212–219). The flip is gated on the roll-call probe
+confirming every active device is on a binary that can unwrap per-device
+manifests. The flip is one-way PER MANIFEST: a manifest written strict drops the
+master wrap on its next version only; already-dual-written manifests stay
+master-readable. Pull paths keep accepting both wraps indefinitely (design doc
+decision 7, lines 108–110, and Phase 3 line 217 — "keep the deserialiser").
+
+Master-key retirement (design doc Phase 4, lines 220–224) is explicitly OUT OF
+SCOPE for this migration and tracked as TIN-1417-followup.
+
+## Rollback (per step)
+
+The migration is reversible at every step because expand never removes a wrap:
+
+- **Steps 1–2 (code lands, flag off)**: revert the PR. No manifest on the wire
+  changed; default-off behavior was byte-identical throughout.
+- **Step 3 (canary, `per_device_wrapping=true`)**: set
+  `crypto.per_device_wrapping=false`. Writers revert to legacy single-wrap.
+  Every manifest written during the canary is dual-written and therefore stays
+  master-readable by every device — nothing is stranded.
+- **Step 4 (signed registry)**: revert to unsigned; signing is additive
+  verification, not a wrap change.
+- **Step 5 (rotation)**: rotation is operator-initiated and idempotent at the
+  prefix level; do not run it, or roll forward only the prefixes you intend.
+- **Step 6 (keychain)**: file fallback remains the documented escape hatch.
+- **Step 7 (strict)**: flip `per_device_wrap_strict=false`. Writers resume
+  dual-write immediately. The one-way property is PER MANIFEST and only takes
+  effect after a green roll-call, so the blast radius of a bad flip is bounded to
+  manifests written while strict was on; those manifests are still readable by
+  every then-active recipient (that is the roll-call precondition). Dual-written
+  manifests from before the flip remain master-readable regardless.
+
+Invariant: dual-written manifests stay master-readable; the strict (master-wrap-
+drop) transition is one-way per manifest and only after roll-call.
+
+## Honest Claim Boundary
+
+Revocation denies NEW content only. This is the load-bearing honesty statement
+from the design doc (Revocation Semantics, lines 164–195) and it does not change
+under this plan:
+
+- A revoked device CANNOT decrypt manifests written after the revocation
+  propagates AND after those files are next rewritten/rekeyed.
+- A revoked device CAN still decrypt anything it already pulled (it holds the
+  FileKey forever — "there is no cryptographic time machine", design doc line
+  180) and anything still carrying a wrap it can open.
+- Critically: content that is already-pulled, OR not-yet-rekeyed, stays
+  master-decryptable until `tcfs key rotate <prefix>` re-chunks and rewraps it.
+  Revocation alone does NOT rewrite historical manifests (design doc lines
+  151–162). Forward secrecy is a SEPARATE, explicit, expensive operator action.
+
+State this plainly in operator and CHANGELOG messaging: "Revoking a device stops
+it from reading newly written content. It does not retroactively lock the device
+out of content it already synced, and it does not lock it out of unchanged files
+until you run `tcfs key rotate`."
+
+## Ratified Seven Questions (design doc lines 280–312)
+
+1. **age vs hpke vs Noise**: Lock to age/X25519 for M11; it is already in tree
+   (design doc decision 1). Revisit HPKE only if stanza shape becomes awkward.
+2. **Keychain coverage**: Fold the keychain trait into `tcfs-secrets` initially
+   (design doc decision 2); no separate crate yet, file fallback dev/test only.
+3. **Revocation propagation transport**: S3 registry is canonical authority;
+   NATS is advisory-only and DEFERRED for this migration (design doc decision 3).
+4. **Forward secrecy default**: Manual — `tcfs device revoke` prints the gap and
+   offers `--rotate-keys`; no surprise multi-GB rewrites (design doc decision 4).
+5. **Multi-tenant boundary**: Recipient sets scoped per-prefix for the first cut
+   (design doc decision 5); per-file deferred to TIN-1418.
+6. **Old PII in invites**: Treat plaintext-secret invites as a user-visible
+   security correction with a CHANGELOG/security note (design doc decision 6).
+7. **Backward-compat window**: Keep v2 single-wrap reads indefinitely; stop
+   WRITING v2 only after the strict cutover gate (design doc decision 7).
+
+## Residual Risks
+
+- **Manual / partial forward secrecy**: revocation is not forward-secret by
+  itself; the operator must run `tcfs key rotate <prefix>` per affected prefix,
+  and any prefix not rotated stays master-decryptable to the revoked device.
+- **Deferred NATS advisory leg**: sub-second revocation propagation is out of
+  scope; the fleet accepts S3 eventual-consistency timing and must document the
+  propagation window.
+- **AES-SIV filename determinism**: deterministic filename encryption leaks
+  equality/structure of names across the recipient set; per-device wrapping does
+  not change this and it is not addressed here.
+- **Headless-Linux keychain**: the secret-service path is not clean on headless
+  Linux daemons (design doc decision 2 / question 2); file fallback remains the
+  documented escape hatch and a known weaker posture there.
+- **Invite authenticity**: invite signing and removal of plaintext storage
+  secrets is TIN-1416 / TIN-1424, not this migration. Production self-enrollment
+  stays disabled until invites no longer carry raw long-lived credentials
+  (design doc lines 116–119, 240–246).
+- **Symlink restore (PR-A)**: the restore path materializes a peer-published
+  symlink target verbatim — `create_local_symlink`
+  (`crates/tcfs-sync/src/engine.rs:2415-2441`) calls
+  `std::os::unix::fs::symlink(target)` at `:2427` with no deny-set, traversal, or
+  absolute-path guard, reached from `download_file_with_device`
+  (`engine.rs:2114`) via all three production restore callers. A hostile peer can
+  publish a `SymlinkManifest` targeting `../../.ssh/authorized_keys` and every
+  pulling host materializes it. Per-device wrapping does NOT mitigate this — a
+  legitimate-but-compromised or hostile recipient is still a valid recipient.
+  Tracked separately as PR-A and must be fixed independently of this migration.
+
+---
+
+This plan is the operator-facing sequencing for TIN-1417. Land alignment in PR
+comments. No flag flips and no fleet mutation occur from merging this doc.

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -1,0 +1,385 @@
+# Repo-Roam Test Plan: dev-env zero-diff fingerprint over the TIN-1620 live-repo ladder
+
+**Status:** runbook / canary plan (agent-drafted, needs operator review)
+**Date:** 2026-06-08
+**Gate:** G5 — one expendable live repo (`TIN-1620`); live-execution child `TIN-1908`
+**Track:** repo-roam == Phase 2 "single live repo" of
+[`large-workdir-onboarding-design-2026-05-25.md`](large-workdir-onboarding-design-2026-05-25.md)
+**Hosts:** `macbook-neo` (Darwin), `honey` (Linux)
+
+---
+
+## 0. What this plan is, and what it is NOT
+
+This is **not new scope**. Repo-roam — "enroll a `~/git` repo so a dev ssh-ing to
+honey/bumble picks up committed + uncommitted + staged + untracked + branch/HEAD +
+stash + agent sessions with zero dev-env difference, via the scheduled
+`tcfs reconcile --path --prefix --execute` unit" — is the **extant** large-workdir
+ladder:
+
+- Phase 2 "single live repo" in
+  [`large-workdir-onboarding-design-2026-05-25.md`](large-workdir-onboarding-design-2026-05-25.md)
+  (Phased Rollout table; `### TIN-1620 One Expendable Live Repo Packet`, lines 445-481).
+- **Gate G5** in
+  [`large-workdir-daily-driver-sequencing-2026-05-30.md`](large-workdir-daily-driver-sequencing-2026-05-30.md)
+  (Gate Model, line 127: *"TIN-1620 acceptance: two-machine
+  browse/hydrate/unsync/rehydrate + conflict (T10/T11) + rollback/fresh-tree
+  restore."*).
+- The **enrollment vehicle** is the already-shipped scheduled-reconcile unit from
+  [`claude-projects-roam-enrollment-2026-06-08.md`](claude-projects-roam-enrollment-2026-06-08.md)
+  (Gate G4 / `TIN-1738`): the `extraReconcileRoots` launchd/systemd unit running
+  `tcfs reconcile --path <p> --prefix <pre> --execute` with the fail-closed
+  `Blacklist::from_sync_config` deny-set. Repo-roam is the **same** mechanism
+  pointed at a `~/git` repo instead of `~/.claude/projects`.
+
+The **only new surface** this plan adds is a **precision layer**: a git-aware
+**dev-env zero-diff fingerprint** asserted on BOTH hosts. It does **not** replace
+any QA-matrix row; it is a tighter assertion *over* existing rows. See §3 for the
+exact row mapping.
+
+The QA matrix is the **existing** one — do not invent rows:
+
+- **T-rows** T1-T15 from the onboarding design (`## QA Matrix`, lines 224-240).
+- **M-rows** M1-M8 from
+  [`lazy-traversal-qa-permutation-matrix-2026-05-09.md`](lazy-traversal-qa-permutation-matrix-2026-05-09.md),
+  cited by the design's Onboarding Pilot Rows table.
+- **G5 / TIN-1620 minimum**: T1, T3, T4, T5, T6, T10, T11 + M3, M5, M5-R, M6, M8.
+
+---
+
+## 1. Reuse map (do NOT rebuild these)
+
+| Need | Reuse | Task |
+| --- | --- | --- |
+| inventory -> isolated shadow -> push -> honey hydrate -> Linux lifecycle (copies the FULL repo incl `.git` as plain files) | `scripts/git-repo-canary.sh` -> `scripts/home-canary-linux-xr-shadow.sh` | `task lazy:git-repo-canary` |
+| read-only pre-enroll inventory (git_present/git_dirty/special-file gate) | `scripts/large-workdir-inventory.py` | `task lazy:large-workdir-inventory` |
+| fresh-tree restore / rollback (the G5 "return to clean exact tree" proof) | `scripts/git-repo-restore-proof.sh` | `task lazy:git-repo-restore-proof` |
+| mounted browse-before-hydrate (T1) + cat-hydrates-exact (T2) + symlink (T12) | `scripts/lazy-hydration-mounted-smoke.sh` | `task lazy:mounted-smoke` |
+| G2/G3 backbone precondition (read-only) | `scripts/honey-backbone-preflight.sh` | `task lazy:honey-backbone-preflight` |
+| neo<->honey unsync/rehydrate, conflict, delete/rename lifecycle (T4-T11 / M-rows) | `scripts/neo-honey-unsynced-rehydrate-demo.sh` + variants | `task lazy:neo-honey-unsynced-rehydrate-plan` etc. |
+| **NEW** — git-aware dev-env zero-diff fingerprint | `scripts/repo-roam-fingerprint.sh` | `task lazy:dev-env-fingerprint` |
+
+Two harnesses referenced below land via their own PRs and are **not yet on
+`main`**, so this plan cites them as integration points rather than dependencies:
+
+- the **TIN-1620 flip-flop** harness (`scripts/tin1620-flipflop-canary-harness.sh`,
+  PR #484) — host-readiness-gated, plan-only by default; wraps the neo<->honey demos.
+- the **Facet-6 .git fsck/conflict** harness
+  (`scripts/git-dotgit-fsck-conflict-harness.sh`, PR #506) — the raw-mode `.git`
+  corruption gate (§7).
+
+The evidence packet shape is the established
+`docs/release/evidence/<run-id>/` convention (`source-inventory/`,
+`shadow-inventory/`, `push/`, `honey/`, `lifecycle/`, `restore-proof/`). This plan
+adds exactly **one** new subtree, `dev-env-fingerprint/`, and **one** gate line.
+
+---
+
+## 2. The dev-env fingerprint tool
+
+`scripts/repo-roam-fingerprint.sh` captures a complete git-SEMANTIC fingerprint of
+a repo and compares two captures, failing on ANY difference:
+
+- `git status --porcelain=v2 --branch` (distinguishes index vs worktree, records
+  the checked-out branch + ahead/behind)
+- HEAD + `symbolic-ref` (branch / detached-HEAD safe) + `write-tree` of the index
+- all refs (`show-ref`) and the branch set
+- staged vs unstaged content (`git diff --cached` / `git diff` hashes) and
+  per-path staged blob shas (`ls-files -s`)
+- untracked set, `stash list` + `refs/stash`, reflog tip
+- **`git fsck --full`** — the corruption gate (clean vs dirty verdict)
+- a sorted `relpath<TAB>mode<TAB>sha256|symlink-target` manifest of tracked +
+  untracked working files, honoring the **same fail-closed deny-set** as the
+  reconcile engine (`.env*`/secret/live-WAL never hashed; recorded `DENIED`) plus
+  `target/ node_modules/ .direnv/` excludes for determinism.
+
+Modes: `capture <repo> <out>`, `compare <a> <b>` (exit 1 on any diff),
+`seed-canary <dir>` (throwaway repo with feature branch + staged + unstaged +
+untracked + stash + exec script + symlink), `self-test` (disposable round-trip).
+
+Self-test / regression: `task lazy:test-dev-env-fingerprint`.
+
+The single green signal is `dev-env-zero-diff=pass`, threaded into the packet's
+`result.env` / `parity-gates.env` next to the existing
+`scoped-project-tree-parity-evidence-complete` gate.
+
+---
+
+## 3. Fingerprint -> existing QA-matrix mapping
+
+The fingerprint does not introduce a new matrix. It is the
+*"…and git confirms the dev env is byte-and-semantically identical, with no
+mid-reconcile corruption"* qualifier on these **existing** rows:
+
+| Existing row (source) | What it already asserts | Fingerprint precision added |
+| --- | --- | --- |
+| **T2 / T3** (design QA Matrix) | exact bytes hydrate / rehydrate on demand | working-file sha256 manifest equality, source vs rehydrated |
+| **T4 / T5 / T6** | clean file/dir unsync; dirty unsync refusal | status/index fingerprint identical after a clean flip-flop; refusal leaves no partial state |
+| **T8 / T9 + M3 / M6** | peer edit/delete/rename rehydrates latest bytes | post-rehydrate fingerprint == the peer's fingerprint |
+| **T10 / T11 + M5 / M5-R** | same-file conflict visible; keep-both recovery | for a repo this means BOTH `.git` states preserved and each fsck-clean |
+| **T12** (symlink parity) | preserve or explicitly fail with a recorded blocker | manifest records every `120000` symlink + target; **reconcile drops these today** (§5) |
+| **T13** (xattrs / modes) | round-trip or documented unsupported | exec-bit/mode round-trips (good); xattrs unsupported (documented) |
+| TIN-1620 packet "rollback proof … clean, exact tree" | fresh-tree restore returns a clean tree | restored-tree fingerprint == pre-push source fingerprint, fsck clean |
+
+The new gate is best treated as sub-row **T13-Z (dev-env zero-diff)** layered on
+T12+T13 — explicitly a *tighter* bar than G5's content-exact minimum, gated behind
+the §5 mitigations. Do **not** claim T13-Z green from existing G5 evidence.
+
+---
+
+## 4. Enrollment: `.git-as-files` is config-scoped, NOT a global flip
+
+Per Facet 4 (verified against source on this branch):
+
+- The `Reconcile` clap variant exposes only `--path/-p`, `--prefix`, `--execute`,
+  `--state` (`crates/tcfs-cli/src/main.rs:288-301`). **There is no
+  `--sync-git-dirs` flag.**
+- `.git` enrollment is gated by `[sync] sync_git_dirs` (default **false**,
+  `crates/tcfs-core/src/config.rs:548`) and the `.git-as-files` choice additionally
+  requires `[sync] git_sync_mode = "raw"` (default is **`"bundle"`**,
+  `config.rs:549`). Raw mode recurses into `.git` and uploads internals as plain
+  objects (`engine.rs:3348-3356`); bundle mode packs a `git bundle` instead.
+- `cmd_reconcile` builds the blacklist via `Blacklist::from_sync_config(&config.sync)`
+  from the single `-c/--config` it loads (`main.rs:6452`), and the gate reads
+  through `allows_git_dirs()` / `git_sync_mode()` at `reconcile.rs:1115-1116` and
+  `engine.rs:3331`.
+
+### Blast radius of a GLOBAL flip (do NOT do this)
+
+Setting `sync_git_dirs = true` in the daemon's shared `/etc/tcfs/config.toml`
+flips it for the long-running daemon AND every default-config CLI call
+(`tcfsd/src/daemon.rs:423` logs `git_dirs = config.sync.sync_git_dirs`). That would
+make the primary `~/tcfs` `sync_root` and the watcher start collecting `.git` for
+**every** repo under any synced root, and (with the default `bundle` mode) trigger
+`collect_git_bundles` across the whole tree — a fleet-wide behavior change. **This
+plan forbids the global flip.**
+
+### The minimal, zero-code, per-root enrollment (recommended)
+
+Point the scheduled unit at a **dedicated per-repo config** with `-c` (or
+`TCFS_CONFIG=`):
+
+```toml
+# ~/.config/tcfs/roam-<repo>.toml  (per-repo, NOT the daemon's shared config)
+sync_root     = "/Users/<you>/git/<repo>"
+remote_prefix = "git-roam/<repo>"          # disposable, repo-scoped prefix
+
+[sync]
+sync_git_dirs   = true       # enroll .git
+git_sync_mode   = "raw"      # operator's choice: .git-as-plain-files (NOT bundle)
+sync_hidden_dirs = true
+```
+
+```
+tcfs reconcile -c ~/.config/tcfs/roam-<repo>.toml \
+  --path ~/git/<repo> --prefix git-roam/<repo> --execute
+```
+
+This scopes the `.git` gate to one root **without touching the daemon's shared
+config** — exactly what the in-tree canary fixture
+(`crates/tcfs-cli/src/main.rs:7461-7497`, which writes `tcfs-canary.toml` with
+`sync_git_dirs = true`, `git_sync_mode = "raw"`) and the `git-repo-canary` evidence
+harness already do. The fail-closed security deny-set (`SECURITY_DIRS`, secret /
+live-WAL suffixes) still applies *underneath* `.git`, so this does **not** bypass
+Gate G0 / `TIN-1737`.
+
+**Verdict:** `~/git` enrollment works **as-is with no Rust change** — via a
+per-repo config on the reconcile unit. An additive `#[arg(long)] sync_git_dirs`
+flag on `Reconcile` is a *nice-to-have* (cleaner one-file unit) but is **not
+required**; if added it must default false (no behavior change) and override
+post-load via `Blacklist::new(...)` instead of `from_sync_config`.
+
+---
+
+## 5. The zero-diff caveat: mtime trap + symlink drop (Facet 5)
+
+A naive `tcfs reconcile` enrollment will **NOT** produce a zero-diff dev env on
+honey as-is. Two blocking defects, both verified in source on this branch:
+
+1. **mtime / index trap.** `SyncManifest` has no source-mtime field (only
+   `written_at`, the publish wall-clock; `manifest.rs:43`), and restore writes via
+   atomic rename with no `set_times`/`utimensat` afterward — the restored file gets
+   a fresh OS mtime. With `.git` synced raw, the restored `.git/index` carries the
+   **source** machine's stat cache while the worktree files beside it get **new**
+   mtimes, so honey's first `git status` force-rehashes the whole tree and smudges
+   the index -> spurious local modification of a synced `.git/index`, sync churn,
+   possible false conflict. There is **no** `git update-index --refresh` anywhere
+   in the codebase to repair this.
+   - **Mitigation (run before the first fingerprint compare):** after rehydrate,
+     run `git -C <repo> update-index --refresh -q` (or a `git status` warm-up)
+     **once**, deterministically, so git rewrites its own stat cache before the dev
+     touches it; then re-sync the smudged `.git/index` as the new synced state.
+     Longer-term fix: preserve mtime on restore (add an mtime field to
+     `SyncManifest`, apply via `filetime`/`utimensat` after the rename and before
+     `make_sync_state_full`).
+
+2. **symlink drop in the reconcile collect path.** `collect_local_set` hardcodes
+   `preserve_symlinks: false` (`reconcile.rs:1120`), so every working-tree symlink
+   is silently dropped — a git-tracked symlink (mode `120000`) then shows as a
+   **deleted** tracked file on honey, failing T12.
+   - **Mitigation:** set `preserve_symlinks: true` (keep `follow_symlinks: false`)
+     in `collect_local_set`; the restore side + ingress deny-set already exist.
+     One-line opt-in.
+
+File **modes / exec bit DO round-trip** (`engine.rs:1969-1976` capture +
+`set_permissions` on restore), so modes are not a zero-diff risk. **xattrs** are
+not captured (document as unsupported per T13). **Empty dirs** and **special
+files** (FIFO/socket/device) are dropped by reconcile but do not affect
+`git status`; the Phase-0 inventory (§6 step R0) flags any repo that contains them.
+
+The fingerprint tool is what makes all of the above **visible** rather than silent:
+it records symlink targets, fsck verdict, and the full manifest, so a failing
+`dev-env-zero-diff` immediately points at the mtime smudge or the missing symlink.
+
+---
+
+## 6. The canary procedure (steps mapped to rows + LIVE markers)
+
+Legend: **[PR]** = exercised by this PR's harness/self-test (no fleet);
+**[LIVE]** = operator/agent-driven on the real neo<->honey fleet, NOT in this PR.
+
+### R0 — Inventory + seed (neo)  · rows: pre-gate, T13 inventory
+
+- **[LIVE]** `task lazy:honey-backbone-preflight` — confirm G2/G3 backbone
+  (`nats_ok`, `storage_ok`, two real `age1…` devices). Hard precondition.
+- **[PR]** Seed a throwaway canary repo and capture its source fingerprint:
+
+  ```
+  scripts/repo-roam-fingerprint.sh seed-canary /tmp/roam-canary
+  scripts/repo-roam-fingerprint.sh capture /tmp/roam-canary \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/source
+  ```
+
+  (For a real expendable repo: `task lazy:large-workdir-inventory` first; require
+  bucket `shadow_pilot_ready`, no blocking special files.)
+
+### R1 — Shadow + enroll + push (neo)  · rows: T1, T2; coverage of uncommitted/staged/untracked as bytes
+
+- **[PR/LIVE]** `task lazy:git-repo-canary` with `--source /tmp/roam-canary`
+  `--allow-dirty-source` and a disposable `--remote .../git-roam/<repo>` prefix —
+  builds the isolated shadow (full repo incl `.git` as plain files), pushes to the
+  disposable prefix. The per-repo `.git-as-files` config (§4) is what scopes the
+  `.git` enrollment.
+- **[LIVE]** In production this is the scheduled `tcfs reconcile -c <per-repo>.toml
+  --path --prefix --execute` unit (§4), not a one-shot, but the canary task proves
+  the same push.
+
+### R2 — Hydrate + fingerprint + compare (honey)  · rows: T1, T2, T3, T12; **gate T13-Z**
+
+- **[LIVE]** On honey: `ls/find` before hydration (T1), `cat` selected file (T2),
+  full hydrate, then the **mtime mitigation** from §5 (`git update-index --refresh
+  -q`) **before** fingerprinting.
+- **[LIVE]** Capture honey's fingerprint and compare to neo's source:
+
+  ```
+  scripts/repo-roam-fingerprint.sh capture <hydrated-repo> \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/rehydrated
+  scripts/repo-roam-fingerprint.sh compare \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/source \
+    docs/release/evidence/<run-id>/dev-env-fingerprint/rehydrated
+  ```
+
+  **Green bar:** `dev-env-zero-diff=pass` AND `fsck=clean` both sides AND no
+  spurious-dirty `git status`. A symlink delta here is the §5 T12 drop; an index
+  delta is the §5 mtime smudge.
+
+### R3 — Flip-flop: unsync neo -> edit+commit honey -> rehydrate neo  · rows: T4, T5, T6, T8, M3, M6
+
+- **[LIVE]** `tcfs unsync <repo>` on neo (clean) -> edit + commit on honey ->
+  rehydrate on neo. Then `compare` neo's rehydrated fingerprint to honey's: must be
+  zero-diff (honey's HEAD/branch/index now on neo, fsck clean).
+- **[LIVE]** Reuse `scripts/neo-honey-unsynced-rehydrate-demo.sh` (and, once
+  landed, the `tin1620-flipflop-canary-harness.sh` readiness gates) for the
+  transport; the fingerprint is the new assertion on top.
+
+### R4 — Rollback / fresh-tree restore  · rows: TIN-1620 packet rollback proof
+
+- **[LIVE]** `task lazy:git-repo-restore-proof` into a clean restore-root, then
+  `capture` the restored tree and `compare` to the R0 source fingerprint: restored
+  == source, fsck clean. This is the G5 "return to a clean, exact tree" proof, now
+  with a git-semantic equality assertion instead of per-file SHA256 only.
+
+### R5 — Conflict / keep-both  · rows: T10, T11, M5, M5-R
+
+- **[LIVE]** Same-file conflict across hosts: conflict visible, local bytes
+  preserved; manual keep-both -> both `.git` states preserved, each fsck-clean and
+  each fingerprint-able. See §7 for the concurrent-`.git` corruption gate.
+
+---
+
+## 7. Concurrent `.git` corruption checks (Facet 6)
+
+Under `git_sync_mode = "raw"` + `conflict_mode = "auto"`, the `AutoResolver`
+resolves each conflicting path independently with **no** awareness that a file is
+part of a `.git` directory, so two machines editing the same repo's `.git`
+concurrently can keep device A's `refs/heads/main` alongside device B's
+object store -> a half-applied ref (`git fsck`:
+`error: refs/heads/main: invalid sha1 pointer`). Aggravator: raw upload checks
+`git_is_safe(.git)` once then streams `.git/*` over many seconds (TOCTOU);
+`acquire_git_lock` exists but is never called on the raw upload path.
+
+The live-repo packet must add five raw-mode `.git` rows (these are the
+`scripts/git-dotgit-fsck-conflict-harness.sh` rows from PR #506, **not** on `main`):
+
+- **G5-git-1 PEER FSCK** — after push-on-A -> rehydrate-on-B, `git fsck --full` is
+  clean, HEAD resolves to a present commit. The fingerprint's `fsck.env` gate
+  enforces this in R2/R3 above.
+- **G5-git-2 NO TORN SNAPSHOT** — a repo with `.git/index.lock` / in-progress
+  rebase is skipped that cycle, never uploaded half-applied.
+- **G5-git-3 CLEAN FLIP-FLOP EXACT** — clean `tcfs unsync` -> rehydrate restores an
+  fsck-clean, byte-exact repo (the R3 fingerprint compare proves this).
+- **G5-git-4 DIRTY-CHILD REFUSAL** — `tcfs unsync` with a dirty `.git` child
+  refuses without `--force`; no partial dehydration (row T6).
+- **G5-git-5 CONCURRENT-WRITE CORRUPTION** — the per-file `.git` conflict interleave
+  under `conflict_mode=auto` MUST be detected by `git fsck` (invalid sha1 pointer).
+  **Until conflict resolution is made `.git`-aware, G5-git-5 is EXPECTED TO FAIL**
+  and stands as the corruption gate that must close before G5 can claim
+  concurrent-edit safety.
+
+**Safe handoff rule:** the `tcfs unsync <repo>` flip-flop is the correct primitive —
+do not let two machines hold the same `.git` hydrated+writable at once. Quiesce git
+on the source host before unsync.
+
+---
+
+## 8. Scale ceiling (claim boundary)
+
+- **Repo-by-repo only.** `TIN-1908`/`TIN-1620` deliberately enroll one repo at a
+  time. Broad `~/git` ownership stays OUT of claim until `TIN-1556` (stable root
+  identity) + `TIN-1416` (subscriptions) land. **Stop rule:** do not bulk-enroll
+  all of `~/git` before two small repos pass R0-R5 in both directions.
+- **Small `.git` first.** `linux-xr` (~6.2 GB mostly `.git`) stays a stress-only
+  target, never a daily-driver enrollment. The serial crypto upload of a multi-GB
+  `.git` can tear mid-cycle (§5/§7), so big-`.git` is explicitly past the Phase-2
+  boundary.
+- **Still NOT claimed** (per TIN-1620 boundary): broad `~/git`, home takeover,
+  production Finder, keep-synced/pin, `/tmp`, general self-service.
+
+### `.git`-as-files vs git-bundle — operator reconciliation item
+
+The shipped acceptance doc's `.git -> Git-safety bundle/restore` root class
+prescribes the **bundle** path for history and warns against naive live
+`.git/objects` mirroring, whereas the operator chose **`.git`-as-plain-files**
+(`git_sync_mode = "raw"`). These are in tension. A raw-mode enrollment must still
+satisfy R4's HEAD/branch/refs/**fsck** assertions — which the fingerprint's
+`fsck.env` + `refs.txt` + `head.env` captures enforce — but the raw path is exactly
+where §7's corruption gate lives. **Flag for operator decision; do not silently
+diverge from the bundle-based R4 acceptance.**
+
+### `stash` is a precision add, not a new ticket
+
+`stash` is not separately enumerated in any ticket; it rides the `.git/refs/stash`
++ reflog restore path. The fingerprint asserts it explicitly (`stash-list.txt`,
+`stash.env`) — a row-level precision add to R4, not a goalpost move.
+
+---
+
+## 9. Guardrails for this plan
+
+- READ-ONLY research + this docs/scripts PR only. No `reconcile --execute` against
+  prod, no daemon/lab changes, no enrolling real repos in this PR.
+- The harness is safe by construction: `seed-canary` refuses `$HOME` / `~/git/*` /
+  filesystem root; `capture` is read-only; the self-test uses a disposable `/tmp`
+  repo. Real repos require an explicit `--source`/`REPO=` argument.
+- All **[LIVE]** steps are operator/agent-driven on the fleet and are **out of
+  scope for this PR**.

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -82,7 +82,10 @@ a repo and compares two captures, failing on ANY difference:
 
 - `git status --porcelain=v2 --branch` (distinguishes index vs worktree, records
   the checked-out branch + ahead/behind)
-- HEAD + `symbolic-ref` (branch / detached-HEAD safe) + `write-tree` of the index
+- HEAD + `symbolic-ref` (branch / detached-HEAD safe). The staged/index identity
+  is captured below via `ls-files -s` blob shas + the `git diff --cached` hash —
+  capture deliberately does **not** run `git write-tree` (that would write tree
+  objects into `<repo>/.git`, breaking the read-only contract)
 - all refs (`show-ref`) and the branch set
 - staged vs unstaged content (`git diff --cached` / `git diff` hashes) and
   per-path staged blob shas (`ls-files -s`)
@@ -101,7 +104,10 @@ Self-test / regression: `task lazy:test-dev-env-fingerprint`.
 
 The single green signal is `dev-env-zero-diff=pass`, threaded into the packet's
 `result.env` / `parity-gates.env` next to the existing
-`scoped-project-tree-parity-evidence-complete` gate.
+`scoped-project-tree-parity-evidence-complete` gate. **A green `self-test` is NOT
+that signal** — see the [PR]/[LIVE] boundary callout in §6: the self-test only
+proves the assertion engine is consistent on one host; the gate-bearing
+`dev-env-zero-diff=pass` comes from the **[LIVE]** R2/R3 cross-host `compare`.
 
 ---
 
@@ -237,6 +243,24 @@ it records symlink targets, fsck verdict, and the full manifest, so a failing
 
 Legend: **[PR]** = exercised by this PR's harness/self-test (no fleet);
 **[LIVE]** = operator/agent-driven on the real neo<->honey fleet, NOT in this PR.
+
+> **[PR] vs [LIVE] boundary — read this before citing any green bar.**
+> A green `task lazy:test-dev-env-fingerprint` / `self-test` proves **only** that
+> the tool is internally consistent: it captures deterministically (same tree ->
+> identical fingerprint) and its negative control trips (a mutated tree ->
+> `compare` fails). It is run against a single disposable `/tmp` repo on **one
+> host**, so it is **NOT** proof of:
+> - **flip-flop zero-diff in either direction** (neo->honey **or** honey->neo) —
+>   that is delegated to the **[LIVE]** R2/R3 steps, which run `capture`/`compare`
+>   across two real hosts;
+> - **live `.git` corruption catching** — the self-test's repos are never torn
+>   mid-reconcile, so `fsck=clean` there proves nothing about concurrent-write
+>   corruption. That is delegated to the **[LIVE]** R2/R5 steps and the **Facet-6
+>   harness** (`scripts/git-dotgit-fsck-conflict-harness.sh`, PR #506; see §7),
+>   whose G5-git-5 row is *expected to fail* until `.git`-aware resolution lands.
+>
+> In short: **[PR] green == the assertion engine works; [LIVE] green == the fleet
+> actually roams with zero diff and no corruption.** Do not conflate the two.
 
 ### R0 — Inventory + seed (neo)  · rows: pre-gate, T13 inventory
 
@@ -379,7 +403,12 @@ diverge from the bundle-based R4 acceptance.**
 - READ-ONLY research + this docs/scripts PR only. No `reconcile --execute` against
   prod, no daemon/lab changes, no enrolling real repos in this PR.
 - The harness is safe by construction: `seed-canary` refuses `$HOME` / `~/git/*` /
-  filesystem root; `capture` is read-only; the self-test uses a disposable `/tmp`
-  repo. Real repos require an explicit `--source`/`REPO=` argument.
+  filesystem root; `capture` is **strictly read-only** — it runs only inspecting
+  plumbing (`fsck`/`status`/`diff`/`ls-files`/`show-ref`/`rev-parse`/`stash
+  list`/`reflog`) plus a plain-file sha256 walk, and never runs `git write-tree`
+  or any index/object-writing command, so it never mutates the target repo (this
+  matters because R0 points `capture` at real expendable repos); the self-test
+  uses a disposable `/tmp` repo. Real repos require an explicit `--source`/`REPO=`
+  argument.
 - All **[LIVE]** steps are operator/agent-driven on the fleet and are **out of
   scope for this PR**.

--- a/docs/ops/repo-roam-test-plan-2026-06-08.md
+++ b/docs/ops/repo-roam-test-plan-2026-06-08.md
@@ -92,9 +92,11 @@ a repo and compares two captures, failing on ANY difference:
 - untracked set, `stash list` + `refs/stash`, reflog tip
 - **`git fsck --full`** — the corruption gate (clean vs dirty verdict)
 - a sorted `relpath<TAB>mode<TAB>sha256|symlink-target` manifest of tracked +
-  untracked working files, honoring the **same fail-closed deny-set** as the
-  reconcile engine (`.env*`/secret/live-WAL never hashed; recorded `DENIED`) plus
-  `target/ node_modules/ .direnv/` excludes for determinism.
+  untracked working files, honoring or exceeding the reconcile engine's
+  **fail-closed deny-set** (`.env*`, credential files such as `auth.json` /
+  `.credentials.json`, SSH/GPG/SOPS secret components, and live SQLite/DB/WAL
+  files are recorded `DENIED`, never hashed) plus `target/ node_modules/
+  .direnv/` excludes for determinism.
 
 Modes: `capture <repo> <out>`, `compare <a> <b>` (exit 1 on any diff),
 `seed-canary <dir>` (throwaway repo with feature branch + staged + unstaged +

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+#
+# Plan-only packet generator for the TCFS `~/git` daily-driver roam story.
+#
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/git-roam-daily-driver-harness.sh [options]
+
+Create a plan-only evidence packet for one repo plus matching agent context.
+This does not call tcfs, ssh, cargo, nix, or mutate the repo.
+
+Options:
+  --repo <path>                 Git worktree to inspect. Default: $PWD
+  --agent-root <path>           Agent context root. Default: ~/.claude/projects
+  --name <name>                 Packet name. Default: basename of --repo
+  --origin-host <host>          Host where work starts. Default: hostname
+  --continuation-host <host>    Host where work continues. Default: honey
+  --third-host <host>           Optional third enrolled host, e.g. bumble
+  --remote-prefix <prefix>      Expected TCFS prefix. Default: git-roam/<name>
+  --evidence-dir <path>         Evidence output dir
+  -h, --help                    Show this help
+
+Environment mirrors:
+  TCFS_GIT_ROAM_REPO
+  TCFS_GIT_ROAM_AGENT_ROOT
+  TCFS_GIT_ROAM_NAME
+  TCFS_GIT_ROAM_ORIGIN_HOST
+  TCFS_GIT_ROAM_CONTINUATION_HOST
+  TCFS_GIT_ROAM_THIRD_HOST
+  TCFS_GIT_ROAM_REMOTE_PREFIX
+  TCFS_GIT_ROAM_EVIDENCE_DIR
+EOF
+}
+
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+canonical_existing_path() {
+  local path="$1"
+  [[ -e "$path" ]] || fail "path does not exist: $path"
+  (cd "$path" && pwd -P)
+}
+
+sanitize_name() {
+  local name="$1"
+  name="${name##*/}"
+  name="$(printf '%s' "$name" | tr -c 'A-Za-z0-9._-' '-')"
+  name="${name#-}"
+  name="${name%-}"
+  [[ -n "$name" ]] || name="repo"
+  printf '%s\n' "$name"
+}
+
+host_name() {
+  hostname 2>/dev/null || printf 'unknown-host\n'
+}
+
+write_tree_hashes() {
+  local root="$1"
+  local output="$2"
+  local mode="$3"
+
+  : >"$output"
+  if [[ ! -d "$root" ]]; then
+    printf 'status=missing root=%s\n' "$root" >"$output"
+    return 0
+  fi
+
+  (
+    cd "$root"
+    case "$mode" in
+      repo)
+        find . -type f \
+          ! -path './.git/*' \
+          ! -path './node_modules/*' \
+          ! -path './target/*' \
+          ! -path './.svelte-kit/*' \
+          ! -path './build/*' \
+          ! -path './.venv/*' \
+          -print | LC_ALL=C sort
+        ;;
+      agent)
+        find . -type f \
+          ! -name 'auth.json' \
+          ! -name '.credentials.json' \
+          ! -name 'mcp-auth.json' \
+          ! -name 'mcp-needs-auth-cache.json' \
+          ! -name '*.sqlite' \
+          ! -name '*.db' \
+          ! -name '*-wal' \
+          ! -name '*-shm' \
+          ! -path './.cache/*' \
+          -print | LC_ALL=C sort
+        ;;
+      *)
+        fail "unknown hash mode: $mode"
+        ;;
+    esac
+  ) | while IFS= read -r rel; do
+    [[ -n "$rel" ]] || continue
+    (cd "$root" && shasum -a 256 "$rel")
+  done >"$output"
+}
+
+write_symlinks() {
+  local root="$1"
+  local output="$2"
+
+  : >"$output"
+  [[ -d "$root" ]] || return 0
+  while IFS= read -r link_path; do
+    [[ -n "$link_path" ]] || continue
+    printf '%s -> %s\n' "$link_path" "$(readlink "$link_path" 2>/dev/null || true)"
+  done < <(find "$root" -type l -print | LC_ALL=C sort)
+}
+
+write_policy_scan() {
+  local root="$1"
+  local label="$2"
+  local output="$3"
+
+  [[ -d "$root" ]] || return 0
+  {
+    while IFS= read -r path; do
+      [[ -n "$path" ]] || continue
+      local base
+      base="$(basename "$path")"
+      case "$path" in
+        */.git|*/.git/*)
+          printf '%s\tgit-safety\t%s\n' "$label" "$path"
+          ;;
+        */node_modules|*/node_modules/*|*/target|*/target/*|*/.svelte-kit|*/.svelte-kit/*|*/build|*/build/*|*/.venv|*/.venv/*)
+          printf '%s\tgenerated-deny\t%s\n' "$label" "$path"
+          ;;
+        */.ssh|*/.ssh/*|*/.gnupg|*/.gnupg/*|*/.config/sops-nix/secrets|*/.config/sops-nix/secrets/*)
+          printf '%s\tsecret-deny\t%s\n' "$label" "$path"
+          ;;
+      esac
+      case "$base" in
+        .env|.env.*|auth.json|.credentials.json|mcp-auth.json|mcp-needs-auth-cache.json|session-env)
+          printf '%s\tsecret-deny\t%s\n' "$label" "$path"
+          ;;
+        *.sqlite|*.db|*-wal|*-shm|*.wal|*.shm)
+          printf '%s\tlive-db-deny\t%s\n' "$label" "$path"
+          ;;
+        *.log)
+          printf '%s\tlog-deny\t%s\n' "$label" "$path"
+          ;;
+      esac
+    done < <(find "$root" -print | LC_ALL=C sort)
+  } >>"$output"
+}
+
+repo_root="${TCFS_GIT_ROAM_REPO:-$PWD}"
+agent_root="${TCFS_GIT_ROAM_AGENT_ROOT:-$HOME/.claude/projects}"
+packet_name="${TCFS_GIT_ROAM_NAME:-}"
+origin_host="${TCFS_GIT_ROAM_ORIGIN_HOST:-$(host_name)}"
+continuation_host="${TCFS_GIT_ROAM_CONTINUATION_HOST:-honey}"
+third_host="${TCFS_GIT_ROAM_THIRD_HOST:-}"
+remote_prefix="${TCFS_GIT_ROAM_REMOTE_PREFIX:-}"
+evidence_dir="${TCFS_GIT_ROAM_EVIDENCE_DIR:-}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      [[ $# -ge 2 ]] || fail "--repo requires a value"
+      repo_root="$2"
+      shift 2
+      ;;
+    --agent-root)
+      [[ $# -ge 2 ]] || fail "--agent-root requires a value"
+      agent_root="$2"
+      shift 2
+      ;;
+    --name)
+      [[ $# -ge 2 ]] || fail "--name requires a value"
+      packet_name="$2"
+      shift 2
+      ;;
+    --origin-host)
+      [[ $# -ge 2 ]] || fail "--origin-host requires a value"
+      origin_host="$2"
+      shift 2
+      ;;
+    --continuation-host)
+      [[ $# -ge 2 ]] || fail "--continuation-host requires a value"
+      continuation_host="$2"
+      shift 2
+      ;;
+    --third-host)
+      [[ $# -ge 2 ]] || fail "--third-host requires a value"
+      third_host="$2"
+      shift 2
+      ;;
+    --remote-prefix)
+      [[ $# -ge 2 ]] || fail "--remote-prefix requires a value"
+      remote_prefix="$2"
+      shift 2
+      ;;
+    --evidence-dir)
+      [[ $# -ge 2 ]] || fail "--evidence-dir requires a value"
+      evidence_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+repo_root="$(canonical_existing_path "$repo_root")"
+git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
+  fail "repo is not a git worktree: $repo_root"
+
+if [[ -z "$packet_name" ]]; then
+  packet_name="$(sanitize_name "$repo_root")"
+else
+  packet_name="$(sanitize_name "$packet_name")"
+fi
+remote_prefix="${remote_prefix:-git-roam/$packet_name}"
+
+if [[ -n "$agent_root" && -d "$agent_root" ]]; then
+  agent_root="$(canonical_existing_path "$agent_root")"
+fi
+
+if [[ -z "$evidence_dir" ]]; then
+  evidence_dir="docs/release/evidence/git-roam-${packet_name}-${timestamp}"
+fi
+mkdir -p "$evidence_dir"
+
+git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' ')"
+
+{
+  printf 'status=plan-only\n'
+  printf 'packet=git-roam-daily-driver\n'
+  printf 'name=%s\n' "$packet_name"
+  printf 'repo=%s\n' "$repo_root"
+  printf 'agent_root=%s\n' "$agent_root"
+  printf 'origin_host=%s\n' "$origin_host"
+  printf 'continuation_host=%s\n' "$continuation_host"
+  printf 'third_host=%s\n' "$third_host"
+  printf 'remote_prefix=%s\n' "$remote_prefix"
+  printf 'dirty_status_count=%s\n' "$git_status_count"
+  printf 'tcfs_mutation=0\n'
+  printf 'ssh_mutation=0\n'
+  printf 'live_repo_claim=0\n'
+  printf 'daily_driver_claim=0\n'
+} >"$evidence_dir/source.env"
+
+{
+  printf '# source git status\n'
+  git -C "$repo_root" status --porcelain=v1 -b
+  printf '\n# head\n'
+  git -C "$repo_root" rev-parse HEAD
+  printf '\n# branch\n'
+  git -C "$repo_root" branch --show-current || true
+  printf '\n# refs\n'
+  git -C "$repo_root" show-ref --heads --tags || true
+} >"$evidence_dir/git-source.txt"
+
+write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo
+write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent
+write_symlinks "$repo_root" "$evidence_dir/symlinks.txt"
+: >"$evidence_dir/policy-deny.txt"
+write_policy_scan "$repo_root" repo "$evidence_dir/policy-deny.txt"
+write_policy_scan "$agent_root" agent "$evidence_dir/policy-deny.txt"
+
+cat >"$evidence_dir/gates.env" <<EOF
+r0_policy_inventory=planned
+r1_single_origin_dirty_wip=pending-live
+r2_reverse_origin=pending-live
+r3_unsync_cloud_only=pending-live
+r4_git_bundle_restore=pending-live
+r5_conflict_independent_edits=pending-live
+r6_third_host=pending-third-host
+EOF
+
+cat >"$evidence_dir/result.env" <<EOF
+status=plan-only
+proof=git-roam-daily-driver-packet-shape
+allowed_claim=packet-shape-only
+live_tcfs_mutation=0
+daily_driver_git_claim=0
+EOF
+
+cat >"$evidence_dir/README.md" <<EOF
+# TCFS Git Roam Daily-Driver Packet
+
+Status: plan-only.
+
+Repo: \`$repo_root\`
+Agent root: \`$agent_root\`
+Origin host: \`$origin_host\`
+Continuation host: \`$continuation_host\`
+Third host: \`$third_host\`
+Remote prefix: \`$remote_prefix\`
+
+This packet records the evidence shape for the \`~/git\` daily-driver roam
+story. It does not call TCFS, SSH, cargo, Nix, or mutate the repo.
+
+Use this packet to wire the live R0-R6 gates from
+\`docs/ops/git-roam-daily-driver-acceptance-2026-06-08.md\`.
+EOF
+
+printf 'git roam daily-driver evidence: %s\n' "$evidence_dir"
+printf 'status: plan-only\n'

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -63,6 +63,43 @@ host_name() {
   hostname 2>/dev/null || printf 'unknown-host\n'
 }
 
+emit_candidate_paths() {
+  local root="$1"
+  local mode="$2"
+
+  (
+    cd "$root"
+    case "$mode" in
+      repo)
+        find . -type f \
+          ! -path './.git/*' \
+          ! -path './node_modules/*' \
+          ! -path './target/*' \
+          ! -path './.svelte-kit/*' \
+          ! -path './build/*' \
+          ! -path './.venv/*' \
+          -print
+        ;;
+      agent)
+        find . -type f \
+          ! -name 'auth.json' \
+          ! -name '.credentials.json' \
+          ! -name 'mcp-auth.json' \
+          ! -name 'mcp-needs-auth-cache.json' \
+          ! -name '*.sqlite' \
+          ! -name '*.db' \
+          ! -name '*-wal' \
+          ! -name '*-shm' \
+          ! -path './.cache/*' \
+          -print
+        ;;
+      *)
+        fail "unknown hash mode: $mode"
+        ;;
+    esac
+  )
+}
+
 write_tree_hashes() {
   local root="$1"
   local output="$2"
@@ -83,40 +120,12 @@ write_tree_hashes() {
   local hashed=0
   local skipped_by_count=0
   local skipped_by_size=0
-  local list_file
-  list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
 
-  (
-    cd "$root"
-    case "$mode" in
-      repo)
-        find . -type f \
-          ! -path './.git/*' \
-          ! -path './node_modules/*' \
-          ! -path './target/*' \
-          ! -path './.svelte-kit/*' \
-          ! -path './build/*' \
-          ! -path './.venv/*' \
-          -print | LC_ALL=C sort
-        ;;
-      agent)
-        find . -type f \
-          ! -name 'auth.json' \
-          ! -name '.credentials.json' \
-          ! -name 'mcp-auth.json' \
-          ! -name 'mcp-needs-auth-cache.json' \
-          ! -name '*.sqlite' \
-          ! -name '*.db' \
-          ! -name '*-wal' \
-          ! -name '*-shm' \
-          ! -path './.cache/*' \
-          -print | LC_ALL=C sort
-        ;;
-      *)
-        fail "unknown hash mode: $mode"
-        ;;
-    esac
-  ) >"$list_file"
+  local list_file=""
+  if [[ "$max_files" == "0" ]]; then
+    list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
+    emit_candidate_paths "$root" "$mode" | LC_ALL=C sort >"$list_file"
+  fi
 
   while IFS= read -r rel; do
     [[ -n "$rel" ]] || continue
@@ -141,8 +150,16 @@ write_tree_hashes() {
     hashed=$((hashed + 1))
     printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
       "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
-  done >"$output" <"$list_file"
-  rm -f "$list_file"
+  done >"$output" < <(
+    if [[ -n "$list_file" ]]; then
+      cat "$list_file"
+    else
+      emit_candidate_paths "$root" "$mode"
+    fi
+  )
+  if [[ -n "$list_file" ]]; then
+    rm -f "$list_file"
+  fi
 
   if [[ ! -s "$meta_output" ]]; then
     printf 'scanned=0\nhashed=0\nskipped_by_count=0\nskipped_by_size=0\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \

--- a/scripts/git-roam-daily-driver-harness.sh
+++ b/scripts/git-roam-daily-driver-harness.sh
@@ -20,6 +20,8 @@ Options:
   --third-host <host>           Optional third enrolled host, e.g. bumble
   --remote-prefix <prefix>      Expected TCFS prefix. Default: git-roam/<name>
   --evidence-dir <path>         Evidence output dir
+  --max-hash-files <n>          Hash at most n files per tree. Default: 5000; 0 = unlimited
+  --max-hash-file-bytes <n>     Skip individual files larger than n bytes. Default: 52428800; 0 = unlimited
   -h, --help                    Show this help
 
 Environment mirrors:
@@ -31,6 +33,8 @@ Environment mirrors:
   TCFS_GIT_ROAM_THIRD_HOST
   TCFS_GIT_ROAM_REMOTE_PREFIX
   TCFS_GIT_ROAM_EVIDENCE_DIR
+  TCFS_GIT_ROAM_MAX_HASH_FILES
+  TCFS_GIT_ROAM_MAX_HASH_FILE_BYTES
 EOF
 }
 
@@ -63,12 +67,24 @@ write_tree_hashes() {
   local root="$1"
   local output="$2"
   local mode="$3"
+  local max_files="$4"
+  local max_file_bytes="$5"
+  local meta_output="$6"
 
   : >"$output"
+  : >"$meta_output"
   if [[ ! -d "$root" ]]; then
     printf 'status=missing root=%s\n' "$root" >"$output"
+    printf 'status=missing\n' >"$meta_output"
     return 0
   fi
+
+  local scanned=0
+  local hashed=0
+  local skipped_by_count=0
+  local skipped_by_size=0
+  local list_file
+  list_file="$(mktemp "${TMPDIR:-/tmp}/tcfs-git-roam-hash-list.XXXXXX")"
 
   (
     cd "$root"
@@ -100,10 +116,38 @@ write_tree_hashes() {
         fail "unknown hash mode: $mode"
         ;;
     esac
-  ) | while IFS= read -r rel; do
+  ) >"$list_file"
+
+  while IFS= read -r rel; do
     [[ -n "$rel" ]] || continue
+    if rel_path_is_denied "$rel"; then
+      continue
+    fi
+    scanned=$((scanned + 1))
+    if [[ "$max_files" != "0" && "$hashed" -ge "$max_files" ]]; then
+      skipped_by_count=1
+      printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+        "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
+      break
+    fi
+    local file_size
+    file_size="$(cd "$root" && wc -c <"$rel" | tr -d ' ')"
+    if [[ "$max_file_bytes" != "0" && "$file_size" -gt "$max_file_bytes" ]]; then
+      skipped_by_size=$((skipped_by_size + 1))
+      printf 'SKIP_SIZE %s %s\n' "$file_size" "$rel"
+      continue
+    fi
     (cd "$root" && shasum -a 256 "$rel")
-  done >"$output"
+    hashed=$((hashed + 1))
+    printf 'scanned=%s\nhashed=%s\nskipped_by_count=%s\nskipped_by_size=%s\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+      "$scanned" "$hashed" "$skipped_by_count" "$skipped_by_size" "$max_files" "$max_file_bytes" >"$meta_output"
+  done >"$output" <"$list_file"
+  rm -f "$list_file"
+
+  if [[ ! -s "$meta_output" ]]; then
+    printf 'scanned=0\nhashed=0\nskipped_by_count=0\nskipped_by_size=0\nmax_hash_files=%s\nmax_hash_file_bytes=%s\n' \
+      "$max_files" "$max_file_bytes" >"$meta_output"
+  fi
 }
 
 write_symlinks() {
@@ -115,7 +159,36 @@ write_symlinks() {
   while IFS= read -r link_path; do
     [[ -n "$link_path" ]] || continue
     printf '%s -> %s\n' "$link_path" "$(readlink "$link_path" 2>/dev/null || true)"
-  done < <(find "$root" -type l -print | LC_ALL=C sort)
+  done >"$output" < <(find "$root" -type l -print | LC_ALL=C sort)
+}
+
+rel_path_is_denied() {
+  local rel="$1"
+  local base
+  base="$(basename "$rel")"
+
+  case "$rel" in
+    ./.git|./.git/*|*/.git|*/.git/*|\
+    ./node_modules|./node_modules/*|*/node_modules|*/node_modules/*|\
+    ./target|./target/*|*/target|*/target/*|\
+    ./.svelte-kit|./.svelte-kit/*|*/.svelte-kit|*/.svelte-kit/*|\
+    ./build|./build/*|*/build|*/build/*|\
+    ./.venv|./.venv/*|*/.venv|*/.venv/*|\
+    ./.ssh|./.ssh/*|*/.ssh|*/.ssh/*|\
+    ./.gnupg|./.gnupg/*|*/.gnupg|*/.gnupg/*|\
+    ./.config/sops-nix/secrets|./.config/sops-nix/secrets/*|*/.config/sops-nix/secrets|*/.config/sops-nix/secrets/*)
+      return 0
+      ;;
+  esac
+
+  case "$base" in
+    .env|.env.*|auth.json|.credentials.json|mcp-auth.json|mcp-needs-auth-cache.json|session-env|\
+    *.sqlite|*.db|*-wal|*-shm|*.wal|*.shm|*.log)
+      return 0
+      ;;
+  esac
+
+  return 1
 }
 
 write_policy_scan() {
@@ -163,6 +236,8 @@ continuation_host="${TCFS_GIT_ROAM_CONTINUATION_HOST:-honey}"
 third_host="${TCFS_GIT_ROAM_THIRD_HOST:-}"
 remote_prefix="${TCFS_GIT_ROAM_REMOTE_PREFIX:-}"
 evidence_dir="${TCFS_GIT_ROAM_EVIDENCE_DIR:-}"
+max_hash_files="${TCFS_GIT_ROAM_MAX_HASH_FILES:-5000}"
+max_hash_file_bytes="${TCFS_GIT_ROAM_MAX_HASH_FILE_BYTES:-52428800}"
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
 
 while [[ $# -gt 0 ]]; do
@@ -207,6 +282,16 @@ while [[ $# -gt 0 ]]; do
       evidence_dir="$2"
       shift 2
       ;;
+    --max-hash-files)
+      [[ $# -ge 2 ]] || fail "--max-hash-files requires a value"
+      max_hash_files="$2"
+      shift 2
+      ;;
+    --max-hash-file-bytes)
+      [[ $# -ge 2 ]] || fail "--max-hash-file-bytes requires a value"
+      max_hash_file_bytes="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -216,6 +301,9 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+[[ "$max_hash_files" =~ ^[0-9]+$ ]] || fail "--max-hash-files must be a non-negative integer"
+[[ "$max_hash_file_bytes" =~ ^[0-9]+$ ]] || fail "--max-hash-file-bytes must be a non-negative integer"
 
 repo_root="$(canonical_existing_path "$repo_root")"
 git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1 ||
@@ -250,6 +338,8 @@ git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' 
   printf 'third_host=%s\n' "$third_host"
   printf 'remote_prefix=%s\n' "$remote_prefix"
   printf 'dirty_status_count=%s\n' "$git_status_count"
+  printf 'max_hash_files=%s\n' "$max_hash_files"
+  printf 'max_hash_file_bytes=%s\n' "$max_hash_file_bytes"
   printf 'tcfs_mutation=0\n'
   printf 'ssh_mutation=0\n'
   printf 'live_repo_claim=0\n'
@@ -267,8 +357,10 @@ git_status_count="$(git -C "$repo_root" status --porcelain=v1 | wc -l | tr -d ' 
   git -C "$repo_root" show-ref --heads --tags || true
 } >"$evidence_dir/git-source.txt"
 
-write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo
-write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent
+write_tree_hashes "$repo_root" "$evidence_dir/tree-source.sha256" repo \
+  "$max_hash_files" "$max_hash_file_bytes" "$evidence_dir/tree-source.hash.env"
+write_tree_hashes "$agent_root" "$evidence_dir/agent-source.sha256" agent \
+  "$max_hash_files" "$max_hash_file_bytes" "$evidence_dir/agent-source.hash.env"
 write_symlinks "$repo_root" "$evidence_dir/symlinks.txt"
 : >"$evidence_dir/policy-deny.txt"
 write_policy_scan "$repo_root" repo "$evidence_dir/policy-deny.txt"

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -31,9 +31,13 @@
 #   self-test [<tmp>]          Seed -> capture -> capture -> compare round-trip in
 #                              a disposable temp dir. Never touches a real repo.
 #
-# Safety: capture is READ-ONLY (it runs `git fsck`/`git status`/`git diff` and a
-# plain-file sha256 walk; it never writes into <repo>). seed-canary refuses to
-# operate on $HOME, anything under ~/git, or a filesystem root.
+# Safety: capture is READ-ONLY. It runs only inspecting plumbing
+# (`git fsck`/`git status`/`git diff`/`git ls-files -s`/`git show-ref`/`git
+# rev-parse`/`git stash list`/`git reflog`) plus a plain-file sha256 walk. It does
+# NOT run `git write-tree`, `git add`, or any command that mutates the index or
+# writes objects into <repo>/.git — it never writes a single byte into <repo>.
+# seed-canary refuses to operate on $HOME, anything under ~/git, or a filesystem
+# root.
 #
 # Deny-set / noise control: the working-file manifest honors the SAME fail-closed
 # deny-set posture as the reconcile engine (Blacklist::from_sync_config:
@@ -169,11 +173,16 @@ cmd_capture() {
     | tr '\0' '\n' >"$out/status.txt" || true
 
   # HEAD + branch (detached-HEAD safe).
+  # NOTE: we deliberately do NOT run `git write-tree` here. write-tree writes new
+  # tree objects into <repo>/.git/objects and can touch the index, which would
+  # violate capture's read-only contract (the live R0 step points capture at real
+  # expendable repos). The staged/index identity is already fully captured below
+  # by `git ls-files -s` (mode-aware per-path blob shas -> index-blobs.txt) and the
+  # `git diff --cached` hash (diff-cached.sha256), so write-tree is redundant.
   {
     printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
     printf 'symbolic_ref=%s\n' "$("${g[@]}" symbolic-ref -q HEAD 2>/dev/null || echo DETACHED)"
     printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
-    printf 'write_tree=%s\n' "$("${g[@]}" write-tree 2>/dev/null || echo NONE)"
   } >"$out/head.env"
 
   # All refs + branch set (so HEAD/branch/refs round-trip is asserted).
@@ -198,10 +207,17 @@ cmd_capture() {
 
   # git fsck --full: the corruption gate. A mid-reconcile / torn .git must NOT
   # produce a clean fsck. We record the raw output AND a normalized verdict.
+  #
+  # Match GENUINE corruption signals only. `git fsck` emits benign informational
+  # notices ("dangling commit <sha>", "dangling blob", "missing blob" for gc'd /
+  # expired reflog tips) on perfectly healthy repos, so we deliberately do NOT
+  # match bare `missing` / `dangling.*commit`. Real corruption surfaces as a
+  # line-anchored `error:` / `fatal:`, an `invalid sha1 pointer`, or a
+  # `broken link` reference.
   local fsck_out="$out/fsck.txt"
   "${g[@]}" fsck --full 2>&1 | sort >"$fsck_out" || true
   local fsck_bad
-  fsck_bad="$(grep -ciE 'invalid sha1 pointer|missing|broken|dangling.*commit|error:|fatal:' "$fsck_out" || true)"
+  fsck_bad="$(grep -ciE '^error:|^fatal:|invalid sha1 pointer|broken link' "$fsck_out" || true)"
   if [[ "$fsck_bad" -eq 0 ]]; then
     printf 'fsck=clean\n' >"$out/fsck.env"
   else

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -134,16 +134,24 @@ default_excludes() {
 
 # Fail-closed deny-set patterns mirrored from Blacklist::from_sync_config so the
 # fingerprint manifest never records a secret/live-WAL path that the reconcile
-# engine itself refuses to push.
+# engine itself refuses to push. This intentionally errs on the side of denying
+# a little more than the engine, never less.
 is_denied_relpath() {
   local rel="$1"
   local base="${rel##*/}"
   case "$base" in
-    .env|.env.*|*.pem|*.key|id_rsa|id_ed25519|*.sqlite|*.sqlite-wal|*.sqlite-shm|*.db-wal|*.db-shm)
+    .credentials.json|auth.json|.netrc|.pgpass|\
+    .env|.env.*|*.env|\
+    *.pem|*.key|id_rsa|id_ed25519|\
+    *.sqlite|*.sqlite3|*.sqlite-wal|*.sqlite-shm|*.db|*.db-wal|*.db-shm)
       return 0 ;;
   esac
   case "$rel" in
-    .ssh/*|.gnupg/*|*/secrets/*) return 0 ;;
+    .ssh|.ssh/*|*/.ssh|*/.ssh/*|\
+    .gnupg|.gnupg/*|*/.gnupg|*/.gnupg/*|\
+    sops-nix|sops-nix/*|*/sops-nix|*/sops-nix/*|\
+    secrets|secrets/*|*/secrets|*/secrets/*)
+      return 0 ;;
   esac
   return 1
 }

--- a/scripts/repo-roam-fingerprint.sh
+++ b/scripts/repo-roam-fingerprint.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+#
+# repo-roam-fingerprint.sh — git-aware dev-env "zero-diff" fingerprint for the
+# TCFS large-workdir repo-roam ladder (Gate G5 / TIN-1620 / TIN-1908).
+#
+# This is the ONE missing precision layer the research identified: it captures a
+# complete git-SEMANTIC dev-env fingerprint of a repo (status, HEAD, branch,
+# staged/unstaged diffs, stash, untracked, per-file modes, symlink targets,
+# `git fsck --full`, and a sha256 manifest of tracked+untracked working files)
+# and a `compare` mode that exits NONZERO on ANY difference.
+#
+# It PLUGS INTO the existing canary/evidence scaffold; it does NOT duplicate it:
+#   * inventory/shadow/push/honey            -> scripts/git-repo-canary.sh
+#                                               (-> scripts/home-canary-linux-xr-shadow.sh)
+#   * fresh-tree restore / rollback (G5)     -> scripts/git-repo-restore-proof.sh
+#   * cross-host flip-flop lifecycle (T/M)   -> the TIN-1620 flip-flop + neo-honey
+#                                               demo harnesses
+#   * read-only inventory                    -> scripts/large-workdir-inventory.py
+# The fingerprint emits one new evidence subtree, `dev-env-fingerprint/`, and one
+# gate line (`dev-env-zero-diff=pass|fail`) to thread into the packet's
+# result.env / parity-gates.env — it is an ADDITIONAL assertion layered on QA
+# rows T2/T3 (exact bytes), T8/T9 + M3/M6 (peer-edit rehydrate), and
+# T10/T11 + M5/M5-R (conflict / keep-both), NOT a replacement for any row.
+#
+# Modes:
+#   capture <repo> <out_dir>   Write a fingerprint of <repo> into <out_dir>.
+#   compare <dir_a> <dir_b>    Diff two captured fingerprints; exit 1 on any diff.
+#   seed-canary <dir>          Build a THROWAWAY repo with a realistic in-progress
+#                              dev state (feature branch + staged + unstaged +
+#                              untracked + stash + exec script + symlink).
+#   self-test [<tmp>]          Seed -> capture -> capture -> compare round-trip in
+#                              a disposable temp dir. Never touches a real repo.
+#
+# Safety: capture is READ-ONLY (it runs `git fsck`/`git status`/`git diff` and a
+# plain-file sha256 walk; it never writes into <repo>). seed-canary refuses to
+# operate on $HOME, anything under ~/git, or a filesystem root.
+#
+# Deny-set / noise control: the working-file manifest honors the SAME fail-closed
+# deny-set posture as the reconcile engine (Blacklist::from_sync_config:
+# .env*/secret/live-WAL-db never enter a push plan or manifest) plus the usual
+# build-output excludes (target/, node_modules/, .direnv/) so the fingerprint
+# stays deterministic and does not leak secrets into evidence.
+#
+set -euo pipefail
+
+PROG="repo-roam-fingerprint"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/repo-roam-fingerprint.sh capture <repo> <out_dir>
+  scripts/repo-roam-fingerprint.sh compare <dir_a> <dir_b>
+  scripts/repo-roam-fingerprint.sh seed-canary <dir>
+  scripts/repo-roam-fingerprint.sh self-test [<tmp_dir>]
+
+Modes:
+  capture       Read-only git-aware dev-env fingerprint of <repo> into <out_dir>.
+  compare       Diff two fingerprints; exit 1 (and print the diff) on any change.
+  seed-canary   Build a throwaway repo with a realistic dirty/in-progress state.
+  self-test     Disposable seed -> capture -> capture -> compare round-trip.
+
+Environment:
+  REPO_ROAM_FP_EXTRA_EXCLUDES   space-separated extra top-level dir names to omit
+                                from the working-file manifest (defaults already
+                                exclude target node_modules .direnv dist build).
+EOF
+}
+
+fail() {
+  printf '%s: error: %s\n' "$PROG" "$*" >&2
+  exit 1
+}
+
+# Portable sha256 of a single file -> bare hex digest on stdout.
+sha256_file() {
+  local f="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$f" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$f" | awk '{print $1}'
+  else
+    fail "need sha256sum or shasum"
+  fi
+}
+
+# Portable sha256 of stdin -> bare hex digest on stdout.
+sha256_stdin() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  else
+    fail "need sha256sum or shasum"
+  fi
+}
+
+# Portable file mode (octal) -> e.g. 100644 / 100755 / 120000-style 0oNNNN.
+file_mode() {
+  local f="$1"
+  if stat -f '%Lp' "$f" >/dev/null 2>&1; then
+    stat -f '%Lp' "$f"           # BSD / macOS
+  else
+    stat -c '%a' "$f"            # GNU / Linux
+  fi
+}
+
+# Canonicalize a path even when its leaf does not yet exist, by resolving the
+# nearest existing ancestor and re-appending the missing tail. Used by the
+# seed-canary safety guard so it can refuse $HOME / ~/git targets pre-mkdir.
+resolve_intended_path() {
+  local p="$1"
+  if [[ -e "$p" ]]; then
+    ( cd "$p" 2>/dev/null && pwd -P ) || printf '%s\n' "$p"
+    return
+  fi
+  local parent base
+  parent="$(dirname -- "$p")"
+  base="$(basename -- "$p")"
+  if [[ -d "$parent" ]]; then
+    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
+  else
+    printf '%s\n' "$p"
+  fi
+}
+
+# Top-level dir names that never belong in a deterministic working-file manifest.
+default_excludes() {
+  printf '%s\n' target node_modules .direnv dist build .next .turbo
+}
+
+# Fail-closed deny-set patterns mirrored from Blacklist::from_sync_config so the
+# fingerprint manifest never records a secret/live-WAL path that the reconcile
+# engine itself refuses to push.
+is_denied_relpath() {
+  local rel="$1"
+  local base="${rel##*/}"
+  case "$base" in
+    .env|.env.*|*.pem|*.key|id_rsa|id_ed25519|*.sqlite|*.sqlite-wal|*.sqlite-shm|*.db-wal|*.db-shm)
+      return 0 ;;
+  esac
+  case "$rel" in
+    .ssh/*|.gnupg/*|*/secrets/*) return 0 ;;
+  esac
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# capture
+# -----------------------------------------------------------------------------
+cmd_capture() {
+  local repo="$1"
+  local out="$2"
+  [[ -n "$repo" && -n "$out" ]] || { usage >&2; exit 2; }
+  [[ -d "$repo" ]] || fail "repo does not exist: $repo"
+  git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || fail "not a git worktree: $repo"
+
+  local repo_canon
+  repo_canon="$(cd "$repo" && pwd -P)"
+  mkdir -p "$out"
+  out="$(cd "$out" && pwd -P)"
+
+  local g=(git -C "$repo_canon")
+
+  # --- raw git-state captures (deterministic, host-path-independent) ----------
+  # status: porcelain=v2 --branch distinguishes index vs worktree and records
+  # the checked-out branch + ahead/behind. -z for stable ordering.
+  "${g[@]}" -c core.quotepath=false status --porcelain=v2 --branch -z 2>/dev/null \
+    | tr '\0' '\n' >"$out/status.txt" || true
+
+  # HEAD + branch (detached-HEAD safe).
+  {
+    printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
+    printf 'symbolic_ref=%s\n' "$("${g[@]}" symbolic-ref -q HEAD 2>/dev/null || echo DETACHED)"
+    printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
+    printf 'write_tree=%s\n' "$("${g[@]}" write-tree 2>/dev/null || echo NONE)"
+  } >"$out/head.env"
+
+  # All refs + branch set (so HEAD/branch/refs round-trip is asserted).
+  "${g[@]}" show-ref 2>/dev/null | sort >"$out/refs.txt" || true
+  "${g[@]}" branch -a --format='%(refname)' 2>/dev/null | sort >"$out/branches.txt" || true
+
+  # Staged (index) vs unstaged (worktree) content, captured as stable hashes.
+  printf '%s' "$("${g[@]}" diff --cached 2>/dev/null || true)" \
+    | sha256_stdin >"$out/diff-cached.sha256" || true
+  printf '%s' "$("${g[@]}" diff 2>/dev/null || true)" \
+    | sha256_stdin >"$out/diff-worktree.sha256" || true
+  # Per-path staged blob shas (index identity, mode-aware).
+  "${g[@]}" ls-files -s 2>/dev/null | sort >"$out/index-blobs.txt" || true
+
+  # Untracked + stash + reflog tip.
+  "${g[@]}" -c core.quotepath=false ls-files --others --exclude-standard 2>/dev/null \
+    | sort >"$out/untracked.txt" || true
+  "${g[@]}" stash list --format='%gd %s' 2>/dev/null >"$out/stash-list.txt" || true
+  printf 'stash_ref=%s\n' "$("${g[@]}" rev-parse -q --verify refs/stash 2>/dev/null || echo NONE)" \
+    >"$out/stash.env"
+  "${g[@]}" reflog --format='%H %gs' 2>/dev/null | head -n 50 >"$out/reflog.txt" || true
+
+  # git fsck --full: the corruption gate. A mid-reconcile / torn .git must NOT
+  # produce a clean fsck. We record the raw output AND a normalized verdict.
+  local fsck_out="$out/fsck.txt"
+  "${g[@]}" fsck --full 2>&1 | sort >"$fsck_out" || true
+  local fsck_bad
+  fsck_bad="$(grep -ciE 'invalid sha1 pointer|missing|broken|dangling.*commit|error:|fatal:' "$fsck_out" || true)"
+  if [[ "$fsck_bad" -eq 0 ]]; then
+    printf 'fsck=clean\n' >"$out/fsck.env"
+  else
+    printf 'fsck=dirty\n' >"$out/fsck.env"
+  fi
+
+  # --- working-file manifest (tracked + untracked) ----------------------------
+  # relpath<TAB>mode<TAB>sha256(or symlink target). Honors the deny-set + build
+  # excludes so the manifest is deterministic and secret-free. Sorted for a
+  # stable, host-independent compare.
+  # default excludes plus any space-separated REPO_ROAM_FP_EXTRA_EXCLUDES, one
+  # top-level dir name per line (tr turns the space-separated env list into lines).
+  local excludes
+  excludes="$(default_excludes)"$'\n'"$(printf '%s' "${REPO_ROAM_FP_EXTRA_EXCLUDES:-}" | tr ' ' '\n')"
+  local manifest="$out/working-manifest.tsv"
+  : >"$manifest"
+
+  # Enumerate tracked + untracked (not ignored) files via git, NUL-delimited.
+  local rel abs top
+  while IFS= read -r -d '' rel; do
+    [[ -n "$rel" ]] || continue
+    top="${rel%%/*}"
+    if printf '%s\n' "$excludes" | grep -qxF -- "$top"; then
+      continue
+    fi
+    if is_denied_relpath "$rel"; then
+      printf '%s\tDENIED\tdeny-set\n' "$rel" >>"$manifest"
+      continue
+    fi
+    abs="$repo_canon/$rel"
+    if [[ -L "$abs" ]]; then
+      local tgt
+      tgt="$(readlink -- "$abs" 2>/dev/null || echo UNREADABLE)"
+      printf '%s\t120000\tsymlink:%s\n' "$rel" "$tgt" >>"$manifest"
+    elif [[ -f "$abs" ]]; then
+      printf '%s\t%s\t%s\n' "$rel" "$(file_mode "$abs")" "$(sha256_file "$abs")" >>"$manifest"
+    fi
+  done < <(
+    {
+      git -C "$repo_canon" ls-files -z 2>/dev/null
+      git -C "$repo_canon" ls-files --others --exclude-standard -z 2>/dev/null
+    }
+  )
+
+  LC_ALL=C sort -o "$manifest" "$manifest"
+
+  # --- the single fingerprint digest ------------------------------------------
+  # One content-addressed digest over every git-semantic capture above. compare
+  # mode diffs the component files for a human-readable delta; this digest is the
+  # one-line gate signal.
+  local fp
+  fp="$(
+    {
+      cat "$out/status.txt" "$out/head.env" "$out/refs.txt" "$out/branches.txt" \
+          "$out/diff-cached.sha256" "$out/diff-worktree.sha256" "$out/index-blobs.txt" \
+          "$out/untracked.txt" "$out/stash-list.txt" "$out/stash.env" \
+          "$out/fsck.env" "$manifest" 2>/dev/null
+    } | sha256_stdin
+  )"
+
+  {
+    printf 'tool=%s\n' "$PROG"
+    printf 'captured_at_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'repo=%s\n' "$repo_canon"
+    printf 'head=%s\n' "$("${g[@]}" rev-parse --verify HEAD 2>/dev/null || echo NONE)"
+    printf 'branch=%s\n' "$("${g[@]}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo NONE)"
+    printf 'status_entries=%s\n' "$("${g[@]}" status --porcelain=v1 2>/dev/null | wc -l | tr -d ' ')"
+    printf 'untracked_entries=%s\n' "$(wc -l <"$out/untracked.txt" | tr -d ' ')"
+    printf 'stash_entries=%s\n' "$(wc -l <"$out/stash-list.txt" | tr -d ' ')"
+    printf 'manifest_entries=%s\n' "$(wc -l <"$manifest" | tr -d ' ')"
+    cat "$out/fsck.env"
+    printf 'fingerprint=%s\n' "$fp"
+  } >"$out/fingerprint.env"
+
+  printf '%s: captured fingerprint of %s -> %s\n' "$PROG" "$repo_canon" "$out"
+  printf 'fingerprint=%s\n' "$fp"
+}
+
+# -----------------------------------------------------------------------------
+# compare
+# -----------------------------------------------------------------------------
+cmd_compare() {
+  local a="$1"
+  local b="$2"
+  [[ -n "$a" && -n "$b" ]] || { usage >&2; exit 2; }
+  [[ -f "$a/fingerprint.env" ]] || fail "no fingerprint at: $a"
+  [[ -f "$b/fingerprint.env" ]] || fail "no fingerprint at: $b"
+
+  local fa fb
+  fa="$(grep '^fingerprint=' "$a/fingerprint.env" | head -n1 | cut -d= -f2-)"
+  fb="$(grep '^fingerprint=' "$b/fingerprint.env" | head -n1 | cut -d= -f2-)"
+
+  # fsck must be clean on BOTH sides — a clean dev env requires a consistent
+  # .git on the roamed-to host, not just per-file byte parity.
+  local fsck_a fsck_b
+  fsck_a="$(grep '^fsck=' "$a/fingerprint.env" | head -n1 | cut -d= -f2-)"
+  fsck_b="$(grep '^fsck=' "$b/fingerprint.env" | head -n1 | cut -d= -f2-)"
+
+  local components=(
+    status.txt head.env refs.txt branches.txt diff-cached.sha256
+    diff-worktree.sha256 index-blobs.txt untracked.txt stash-list.txt
+    stash.env fsck.env working-manifest.tsv
+  )
+  local diff_out="${REPO_ROAM_FP_COMPARE_DIFF:-}"
+  local tmp_diff
+  tmp_diff="$(mktemp "${TMPDIR:-/tmp}/repo-roam-fp-compare.XXXXXX")"
+  local f
+  for f in "${components[@]}"; do
+    if [[ -f "$a/$f" || -f "$b/$f" ]]; then
+      diff -u "$a/$f" "$b/$f" >>"$tmp_diff" 2>&1 || true
+    fi
+  done
+
+  local status=pass
+  if [[ "$fa" != "$fb" ]]; then status=fail; fi
+  if [[ "$fsck_a" != "clean" || "$fsck_b" != "clean" ]]; then status=fail; fi
+
+  if [[ -n "$diff_out" ]]; then
+    cp "$tmp_diff" "$diff_out"
+  fi
+
+  if [[ "$status" == "pass" ]]; then
+    printf '%s: dev-env-zero-diff=pass (fingerprints match, fsck clean both sides)\n' "$PROG"
+    printf 'dev-env-zero-diff=pass\n'
+    rm -f "$tmp_diff"
+    return 0
+  fi
+
+  printf '%s: dev-env-zero-diff=FAIL\n' "$PROG" >&2
+  printf '  fingerprint A=%s\n  fingerprint B=%s\n' "$fa" "$fb" >&2
+  printf '  fsck A=%s  fsck B=%s\n' "$fsck_a" "$fsck_b" >&2
+  if [[ -s "$tmp_diff" ]]; then
+    printf '  --- component diff ---\n' >&2
+    sed 's/^/  /' "$tmp_diff" >&2
+  fi
+  printf 'dev-env-zero-diff=fail\n'
+  rm -f "$tmp_diff"
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# seed-canary — throwaway repo with a realistic in-progress dev state.
+# -----------------------------------------------------------------------------
+cmd_seed_canary() {
+  local dir="$1"
+  [[ -n "$dir" ]] || { usage >&2; exit 2; }
+
+  # Safety: never operate on a real working tree. Resolve the INTENDED target
+  # even when the leaf does not yet exist (canonicalize its parent), and resolve
+  # $HOME the same way, so the guard catches $HOME and ~/git/* before any mkdir
+  # regardless of /tmp -> /private/tmp style symlinks.
+  case "$dir" in
+    /) fail "refusing to seed at filesystem root" ;;
+  esac
+  local dir_canon home_canon git_root
+  dir_canon="$(resolve_intended_path "$dir")"
+  home_canon="$(resolve_intended_path "$HOME")"
+  git_root="$home_canon/git"
+  # Compare both the resolved form and the raw literal (covers a non-existent
+  # $HOME that cannot be canonicalized).
+  if [[ "$dir_canon" == "$home_canon" || "$dir" == "$HOME" ]]; then
+    fail "refusing to seed canary at \$HOME"
+  fi
+  case "$dir_canon" in
+    "$git_root"|"$git_root"/*) fail "refusing to seed canary under ~/git (real repos)" ;;
+  esac
+  case "$dir" in
+    "$HOME"/git|"$HOME"/git/*) fail "refusing to seed canary under ~/git (real repos)" ;;
+  esac
+
+  mkdir -p "$dir"
+  dir="$(cd "$dir" && pwd -P)"
+
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.name "TCFS Roam Canary"
+  git -C "$dir" config user.email "tcfs-roam-canary@example.invalid"
+  git -C "$dir" config commit.gpgsign false
+
+  # Committed history.
+  printf '# roam canary\n\nthrowaway fixture\n' >"$dir/README.md"
+  mkdir -p "$dir/src"
+  printf 'fn main() {}\n' >"$dir/src/main.rs"
+  git -C "$dir" add README.md src/main.rs
+  git -C "$dir" commit -q -m "initial canary commit"
+  printf 'committed-line\n' >>"$dir/src/main.rs"
+  git -C "$dir" commit -qam "second canary commit"
+
+  # Feature branch checked out (branch/HEAD must round-trip).
+  git -C "$dir" checkout -q -b feature/in-progress
+
+  # A stash (refs/stash + reflog must round-trip).
+  printf 'work-to-stash\n' >>"$dir/README.md"
+  git -C "$dir" stash push -q -m "canary wip stash"
+
+  # Staged change (index / git diff --cached).
+  printf 'staged-line\n' >>"$dir/src/main.rs"
+  git -C "$dir" add src/main.rs
+
+  # Unstaged change on a tracked file (worktree / git diff).
+  printf '\nunstaged tail\n' >>"$dir/README.md"
+
+  # Untracked file.
+  printf 'untracked scratch\n' >"$dir/NOTES.txt"
+
+  # Executable script (mode/exec bit must round-trip — T13 modes half).
+  printf '#!/usr/bin/env bash\necho canary\n' >"$dir/run.sh"
+  chmod +x "$dir/run.sh"
+  git -C "$dir" add run.sh
+
+  # Symlink (T12 symlink parity — the reconcile collect path drops these today
+  # unless preserve_symlinks is opted in; the fingerprint makes that visible).
+  ln -s README.md "$dir/README.link"
+
+  printf '%s: seeded throwaway canary repo at %s\n' "$PROG" "$dir"
+  printf '  branch=%s head=%s\n' \
+    "$(git -C "$dir" rev-parse --abbrev-ref HEAD)" \
+    "$(git -C "$dir" rev-parse --short HEAD)"
+}
+
+# -----------------------------------------------------------------------------
+# self-test — disposable seed -> capture -> capture -> compare round-trip.
+# -----------------------------------------------------------------------------
+cmd_self_test() {
+  local base="${1:-}"
+  if [[ -z "$base" ]]; then
+    base="$(mktemp -d "${TMPDIR:-/tmp}/repo-roam-fp-selftest.XXXXXX")"
+    local own=1
+  else
+    mkdir -p "$base"
+    base="$(cd "$base" && pwd -P)"
+    local own=0
+  fi
+  local rc=0
+  (
+    set -e
+    local repo="$base/canary-repo"
+    local fp_a="$base/fp-a"
+    local fp_b="$base/fp-b"
+    cmd_seed_canary "$repo"
+    cmd_capture "$repo" "$fp_a"
+    # Second capture of the SAME unchanged tree must be byte-identical
+    # (proves the fingerprint is deterministic — the precondition for a
+    # source-vs-rehydrated zero-diff comparison).
+    cmd_capture "$repo" "$fp_b"
+    REPO_ROAM_FP_COMPARE_DIFF="$base/compare.diff" cmd_compare "$fp_a" "$fp_b"
+
+    # Negative control: mutate the tree, re-capture, compare MUST fail.
+    printf 'drift\n' >>"$repo/NOTES.txt"
+    local fp_c="$base/fp-c"
+    cmd_capture "$repo" "$fp_c"
+    if cmd_compare "$fp_a" "$fp_c" >/dev/null 2>&1; then
+      printf '%s: self-test FAILED: drift not detected\n' "$PROG" >&2
+      exit 1
+    fi
+    printf '%s: self-test PASSED (deterministic match + drift detected)\n' "$PROG"
+  ) || rc=$?
+  if [[ "$own" -eq 1 ]]; then
+    rm -rf "$base"
+  fi
+  return "$rc"
+}
+
+main() {
+  local mode="${1:-}"
+  [[ -n "$mode" ]] || { usage >&2; exit 2; }
+  shift || true
+  case "$mode" in
+    capture)     cmd_capture "${1:-}" "${2:-}" ;;
+    compare)     cmd_compare "${1:-}" "${2:-}" ;;
+    seed-canary) cmd_seed_canary "${1:-}" ;;
+    self-test)   cmd_self_test "${1:-}" ;;
+    -h|--help)   usage ;;
+    *) printf '%s: unknown mode: %s\n' "$PROG" "$mode" >&2; usage >&2; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test-git-roam-daily-driver-harness.sh
+++ b/scripts/test-git-roam-daily-driver-harness.sh
@@ -66,6 +66,8 @@ bash "$SCRIPT" \
   --continuation-host honey \
   --third-host bumble \
   --remote-prefix git/ci-templates \
+  --max-hash-files 1 \
+  --max-hash-file-bytes 20 \
   --evidence-dir "$EVIDENCE" \
   >"$OUT"
 
@@ -76,13 +78,17 @@ assert_contains "$EVIDENCE/source.env" "origin_host=neo"
 assert_contains "$EVIDENCE/source.env" "continuation_host=honey"
 assert_contains "$EVIDENCE/source.env" "third_host=bumble"
 assert_contains "$EVIDENCE/source.env" "remote_prefix=git/ci-templates"
+assert_contains "$EVIDENCE/source.env" "max_hash_files=1"
+assert_contains "$EVIDENCE/source.env" "max_hash_file_bytes=20"
 assert_contains "$EVIDENCE/source.env" "tcfs_mutation=0"
 assert_contains "$EVIDENCE/source.env" "daily_driver_claim=0"
 assert_contains "$EVIDENCE/git-source.txt" "##"
 assert_contains "$EVIDENCE/git-source.txt" "README.md"
-assert_contains "$EVIDENCE/tree-source.sha256" "./README.md"
-assert_contains "$EVIDENCE/tree-source.sha256" "./src/new.txt"
+assert_contains "$EVIDENCE/tree-source.hash.env" "hashed=1"
+assert_contains "$EVIDENCE/tree-source.hash.env" "skipped_by_count="
+assert_contains "$EVIDENCE/tree-source.hash.env" "max_hash_files=1"
 assert_contains "$EVIDENCE/agent-source.sha256" "./project-one/session.jsonl"
+assert_contains "$EVIDENCE/agent-source.hash.env" "hashed=1"
 assert_contains "$EVIDENCE/policy-deny.txt" "secret-deny"
 assert_contains "$EVIDENCE/policy-deny.txt" ".env.local"
 assert_contains "$EVIDENCE/policy-deny.txt" "generated-deny"
@@ -91,6 +97,19 @@ assert_contains "$EVIDENCE/policy-deny.txt" "live-db-deny"
 assert_contains "$EVIDENCE/gates.env" "r1_single_origin_dirty_wip=pending-live"
 assert_contains "$EVIDENCE/result.env" "daily_driver_git_claim=0"
 assert_contains "$EVIDENCE/README.md" "Status: plan-only."
+
+UNBOUNDED="$TMPDIR/evidence-unbounded"
+bash "$SCRIPT" \
+  --repo "$FIXTURE" \
+  --agent-root "$AGENT" \
+  --name ci-templates \
+  --max-hash-files 0 \
+  --max-hash-file-bytes 0 \
+  --evidence-dir "$UNBOUNDED" \
+  >"$TMPDIR/out-unbounded.txt"
+assert_contains "$UNBOUNDED/tree-source.sha256" "./README.md"
+assert_contains "$UNBOUNDED/tree-source.sha256" "./src/new.txt"
+assert_contains "$UNBOUNDED/agent-source.sha256" "./project-one/session.jsonl"
 
 NOT_GIT="$TMPDIR/not-git"
 mkdir -p "$NOT_GIT"

--- a/scripts/test-git-roam-daily-driver-harness.sh
+++ b/scripts/test-git-roam-daily-driver-harness.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Regression tests for git-roam-daily-driver-harness.sh.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/git-roam-daily-driver-harness.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-git-roam-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+
+  local out="$TMPDIR/failure.out"
+  local err="$TMPDIR/failure.err"
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  cat "$out" "$err" >"$TMPDIR/failure.combined"
+  assert_contains "$TMPDIR/failure.combined" "$expected"
+}
+
+FIXTURE="$TMPDIR/repo"
+AGENT="$TMPDIR/agent"
+EVIDENCE="$TMPDIR/evidence"
+mkdir -p "$FIXTURE/src" "$AGENT/project-one"
+
+git -C "$FIXTURE" init -q
+git -C "$FIXTURE" config user.name "TCFS Test"
+git -C "$FIXTURE" config user.email "tcfs-test@example.invalid"
+git -C "$FIXTURE" config commit.gpgsign false
+printf '# fixture\n' >"$FIXTURE/README.md"
+printf 'fn main() {}\n' >"$FIXTURE/src/main.rs"
+git -C "$FIXTURE" add README.md src/main.rs
+git -C "$FIXTURE" commit -q -m "initial fixture"
+
+printf 'changed\n' >>"$FIXTURE/README.md"
+printf 'new file\n' >"$FIXTURE/src/new.txt"
+mkdir -p "$FIXTURE/node_modules/pkg"
+printf 'generated\n' >"$FIXTURE/node_modules/pkg/generated.js"
+printf 'secret\n' >"$FIXTURE/.env.local"
+printf 'session line\n' >"$AGENT/project-one/session.jsonl"
+printf 'db\n' >"$AGENT/project-one/state.sqlite"
+
+OUT="$TMPDIR/out.txt"
+bash "$SCRIPT" \
+  --repo "$FIXTURE" \
+  --agent-root "$AGENT" \
+  --name ci-templates \
+  --origin-host neo \
+  --continuation-host honey \
+  --third-host bumble \
+  --remote-prefix git/ci-templates \
+  --evidence-dir "$EVIDENCE" \
+  >"$OUT"
+
+assert_contains "$OUT" "git roam daily-driver evidence:"
+assert_contains "$EVIDENCE/source.env" "status=plan-only"
+assert_contains "$EVIDENCE/source.env" "name=ci-templates"
+assert_contains "$EVIDENCE/source.env" "origin_host=neo"
+assert_contains "$EVIDENCE/source.env" "continuation_host=honey"
+assert_contains "$EVIDENCE/source.env" "third_host=bumble"
+assert_contains "$EVIDENCE/source.env" "remote_prefix=git/ci-templates"
+assert_contains "$EVIDENCE/source.env" "tcfs_mutation=0"
+assert_contains "$EVIDENCE/source.env" "daily_driver_claim=0"
+assert_contains "$EVIDENCE/git-source.txt" "##"
+assert_contains "$EVIDENCE/git-source.txt" "README.md"
+assert_contains "$EVIDENCE/tree-source.sha256" "./README.md"
+assert_contains "$EVIDENCE/tree-source.sha256" "./src/new.txt"
+assert_contains "$EVIDENCE/agent-source.sha256" "./project-one/session.jsonl"
+assert_contains "$EVIDENCE/policy-deny.txt" "secret-deny"
+assert_contains "$EVIDENCE/policy-deny.txt" ".env.local"
+assert_contains "$EVIDENCE/policy-deny.txt" "generated-deny"
+assert_contains "$EVIDENCE/policy-deny.txt" "node_modules"
+assert_contains "$EVIDENCE/policy-deny.txt" "live-db-deny"
+assert_contains "$EVIDENCE/gates.env" "r1_single_origin_dirty_wip=pending-live"
+assert_contains "$EVIDENCE/result.env" "daily_driver_git_claim=0"
+assert_contains "$EVIDENCE/README.md" "Status: plan-only."
+
+NOT_GIT="$TMPDIR/not-git"
+mkdir -p "$NOT_GIT"
+assert_fails_contains \
+  "repo is not a git worktree" \
+  bash "$SCRIPT" --repo "$NOT_GIT" --evidence-dir "$TMPDIR/not-git-evidence"
+
+printf 'git roam daily-driver harness tests passed\n'

--- a/scripts/test-repo-roam-fingerprint.sh
+++ b/scripts/test-repo-roam-fingerprint.sh
@@ -71,20 +71,52 @@ assert_contains "$FP_A/working-manifest.tsv" "run.sh"
 # untracked file present.
 assert_contains "$FP_A/untracked.txt" "NOTES.txt"
 
-# --- deny-set posture: a planted secret is recorded DENIED, never hashed -----
-printf 'SECRET=should-not-appear\n' >"$REPO/.env"
-git -C "$REPO" add -f .env
+# --- deny-set posture: planted secrets are recorded DENIED, never hashed -----
+secret_paths=(
+  ".env"
+  ".env.local"
+  "service.env"
+  ".credentials.json"
+  "auth.json"
+  ".netrc"
+  ".pgpass"
+  "logs_2.sqlite"
+  "logs_2.sqlite3"
+  "logs_2.sqlite-wal"
+  "logs_2.sqlite-shm"
+  "opencode.db"
+  "opencode.db-wal"
+  "opencode.db-shm"
+  ".ssh/id_ed25519"
+  ".gnupg/private-keys-v1.d/key"
+  "sops-nix/secrets/example"
+  "nested/secrets/token"
+)
+for secret_path in "${secret_paths[@]}"; do
+  mkdir -p "$REPO/$(dirname "$secret_path")"
+  printf 'SECRET=should-not-appear:%s\n' "$secret_path" >"$REPO/$secret_path"
+  git -C "$REPO" add -f "$secret_path"
+done
 FP_DENY="$TMPDIR/fp-deny"
 bash "$SCRIPT" capture "$REPO" "$FP_DENY" >/dev/null
-assert_contains "$FP_DENY/working-manifest.tsv" ".env"
-assert_contains "$FP_DENY/working-manifest.tsv" "DENIED"
+for secret_path in "${secret_paths[@]}"; do
+  assert_contains "$FP_DENY/working-manifest.tsv" "$secret_path"
+  if ! awk -F '\t' -v path="$secret_path" '$1 == path && $2 == "DENIED" { found=1 } END { exit found ? 0 : 1 }' \
+      "$FP_DENY/working-manifest.tsv"; then
+    printf 'expected %s to be recorded as DENIED\n' "$secret_path" >&2
+    cat "$FP_DENY/working-manifest.tsv" >&2
+    exit 1
+  fi
+done
 if grep -F 'should-not-appear' "$FP_DENY"/* >/dev/null 2>&1; then
   printf 'secret content leaked into fingerprint evidence\n' >&2
   exit 1
 fi
-# reset the planted secret out of the way for the unchanged-compare below.
-git -C "$REPO" rm -q --cached .env
-rm -f "$REPO/.env"
+# reset the planted secrets out of the way for the unchanged-compare below.
+git -C "$REPO" rm -qr --cached -- "${secret_paths[@]}"
+for secret_path in "${secret_paths[@]}"; do
+  rm -f "$REPO/$secret_path"
+done
 
 # --- compare: identical re-capture passes ------------------------------------
 FP_B="$TMPDIR/fp-b"

--- a/scripts/test-repo-roam-fingerprint.sh
+++ b/scripts/test-repo-roam-fingerprint.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# Regression tests for repo-roam-fingerprint.sh. Disposable /tmp repos only;
+# never touches a real worktree.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/repo-roam-fingerprint.sh"
+TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/tcfs-repo-roam-fp-test.XXXXXX")"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected to find %s in %s\n' "$expected" "$file" >&2
+    printf '%s\n' '--- output ---' >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_fails_contains() {
+  local expected="$1"
+  shift
+  local out="$TMPDIR/failure.out"
+  local err="$TMPDIR/failure.err"
+  if "$@" >"$out" 2>"$err"; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+  cat "$out" "$err" >"$TMPDIR/failure.combined"
+  assert_contains "$TMPDIR/failure.combined" "$expected"
+}
+
+# --- self-test mode round-trips (deterministic + drift detection) ------------
+SELFTEST_OUT="$TMPDIR/selftest.out"
+bash "$SCRIPT" self-test "$TMPDIR/selftest-base" >"$SELFTEST_OUT" 2>&1
+assert_contains "$SELFTEST_OUT" "self-test PASSED"
+assert_contains "$SELFTEST_OUT" "dev-env-zero-diff=pass"
+
+# --- seed-canary builds the expected dirty/in-progress state -----------------
+REPO="$TMPDIR/canary"
+bash "$SCRIPT" seed-canary "$REPO" >"$TMPDIR/seed.out"
+assert_contains "$TMPDIR/seed.out" "seeded throwaway canary repo"
+test -d "$REPO/.git"
+test -L "$REPO/README.link"
+test -x "$REPO/run.sh"
+# feature branch checked out, stash present.
+[[ "$(git -C "$REPO" rev-parse --abbrev-ref HEAD)" == "feature/in-progress" ]]
+[[ "$(git -C "$REPO" stash list | wc -l | tr -d ' ')" == "1" ]]
+
+# --- capture writes the full fingerprint surface -----------------------------
+FP_A="$TMPDIR/fp-a"
+bash "$SCRIPT" capture "$REPO" "$FP_A" >"$TMPDIR/capture-a.out"
+assert_contains "$TMPDIR/capture-a.out" "captured fingerprint of"
+for f in fingerprint.env status.txt head.env refs.txt branches.txt \
+         diff-cached.sha256 diff-worktree.sha256 index-blobs.txt \
+         untracked.txt stash-list.txt stash.env reflog.txt fsck.txt \
+         fsck.env working-manifest.tsv; do
+  test -f "$FP_A/$f" || { printf 'missing capture file: %s\n' "$f" >&2; exit 1; }
+done
+assert_contains "$FP_A/fingerprint.env" "fsck=clean"
+assert_contains "$FP_A/fingerprint.env" "branch=feature/in-progress"
+assert_contains "$FP_A/fingerprint.env" "stash_entries=1"
+# symlink + exec mode recorded in the working manifest.
+assert_contains "$FP_A/working-manifest.tsv" "README.link"
+assert_contains "$FP_A/working-manifest.tsv" "symlink:README.md"
+assert_contains "$FP_A/working-manifest.tsv" "run.sh"
+# untracked file present.
+assert_contains "$FP_A/untracked.txt" "NOTES.txt"
+
+# --- deny-set posture: a planted secret is recorded DENIED, never hashed -----
+printf 'SECRET=should-not-appear\n' >"$REPO/.env"
+git -C "$REPO" add -f .env
+FP_DENY="$TMPDIR/fp-deny"
+bash "$SCRIPT" capture "$REPO" "$FP_DENY" >/dev/null
+assert_contains "$FP_DENY/working-manifest.tsv" ".env"
+assert_contains "$FP_DENY/working-manifest.tsv" "DENIED"
+if grep -F 'should-not-appear' "$FP_DENY"/* >/dev/null 2>&1; then
+  printf 'secret content leaked into fingerprint evidence\n' >&2
+  exit 1
+fi
+# reset the planted secret out of the way for the unchanged-compare below.
+git -C "$REPO" rm -q --cached .env
+rm -f "$REPO/.env"
+
+# --- compare: identical re-capture passes ------------------------------------
+FP_B="$TMPDIR/fp-b"
+bash "$SCRIPT" capture "$REPO" "$FP_B" >/dev/null
+CMP_OUT="$TMPDIR/compare.out"
+bash "$SCRIPT" compare "$FP_A" "$FP_B" >"$CMP_OUT"
+assert_contains "$CMP_OUT" "dev-env-zero-diff=pass"
+
+# --- compare: a real change fails with a diff --------------------------------
+printf 'drift\n' >>"$REPO/NOTES.txt"
+FP_C="$TMPDIR/fp-c"
+bash "$SCRIPT" capture "$REPO" "$FP_C" >/dev/null
+assert_fails_contains \
+  "dev-env-zero-diff" \
+  bash "$SCRIPT" compare "$FP_A" "$FP_C"
+
+# --- safety: seed-canary refuses HOME ----------------------------------------
+assert_fails_contains \
+  "refusing to seed canary at \$HOME" \
+  env HOME="$TMPDIR/fakehome" bash "$SCRIPT" seed-canary "$TMPDIR/fakehome"
+
+# --- safety: seed-canary refuses ~/git/<repo> --------------------------------
+mkdir -p "$TMPDIR/fakehome2/git"
+assert_fails_contains \
+  "refusing to seed canary under ~/git" \
+  env HOME="$TMPDIR/fakehome2" bash "$SCRIPT" seed-canary "$TMPDIR/fakehome2/git/somerepo"
+
+# --- capture refuses a non-git dir -------------------------------------------
+mkdir -p "$TMPDIR/not-git"
+assert_fails_contains \
+  "not a git worktree" \
+  bash "$SCRIPT" capture "$TMPDIR/not-git" "$TMPDIR/fp-not-git"
+
+printf 'repo-roam-fingerprint tests passed\n'

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -372,30 +372,178 @@ struct TCFSProviderApp {
             return config
         }
 
+        // (1) Master-key material — the established inlining (host reads
+        //     master_key_file from ~/.config/tcfs and inlines master_key_base64
+        //     so the sandboxed FileProvider .appex can decrypt without an fs read).
         if let encoded = object["master_key_base64"] as? String, !encoded.isEmpty {
-            return serializeConfigObject(object, fallback: config)
-        }
-
-        guard let keyPath = object["master_key_file"] as? String, !keyPath.isEmpty else {
+            // Already inlined; still try the per-device enrichment below.
+        } else if let keyPath = object["master_key_file"] as? String, !keyPath.isEmpty {
+            let expandedKeyPath = (keyPath as NSString).expandingTildeInPath
+            let keyURL = URL(fileURLWithPath: expandedKeyPath)
+            if let keyData = try? Data(contentsOf: keyURL) {
+                if keyData.count == 32 {
+                    object["master_key_base64"] = keyData.base64EncodedString()
+                    hostEvent("provisionConfig: added master key material to Keychain copy")
+                } else {
+                    hostEvent(
+                        "provisionConfig: master_key_file has invalid byte length \(keyData.count)"
+                    )
+                }
+            } else {
+                hostEvent("provisionConfig: master_key_file could not be read")
+            }
+        } else {
             hostLogger.warning("provisionConfig: no master_key_file for Keychain enrichment")
-            return serializeConfigObject(object, fallback: config)
         }
 
-        let expandedKeyPath = (keyPath as NSString).expandingTildeInPath
-        let keyURL = URL(fileURLWithPath: expandedKeyPath)
-        guard let keyData = try? Data(contentsOf: keyURL) else {
-            hostEvent("provisionConfig: master_key_file could not be read")
-            return serializeConfigObject(object, fallback: config)
-        }
+        // (2) Per-device material (TIN-1417) — inert unless wrap_mode is
+        //     dual/per_device. The macOS FileProvider .appex cannot fs-read
+        //     ~/.config/tcfs (devices.json / device-<id>.age), so the host (which
+        //     CAN read them) inlines the active recipients + this device's age
+        //     secret into the Keychain config copy, mirroring master_key_base64.
+        enrichPerDeviceMaterial(&object)
 
-        guard keyData.count == 32 else {
-            hostEvent("provisionConfig: master_key_file has invalid byte length \(keyData.count)")
-            return serializeConfigObject(object, fallback: config)
-        }
-
-        object["master_key_base64"] = keyData.base64EncodedString()
-        hostEvent("provisionConfig: added master key material to Keychain copy")
         return serializeConfigObject(object, fallback: config)
+    }
+
+    /// Returns true when the config selects a non-master wrap mode (dual /
+    /// per_device, or the legacy `per_device_wrapping: true` alias). Per-device
+    /// Keychain inlining is INERT for the default `master` mode — the inlined
+    /// fields are simply not written, keeping wrap_mode=master byte-identical.
+    private static func wrapModeIsPerDevice(_ object: [String: Any]) -> Bool {
+        if let mode = object["wrap_mode"] as? String, !mode.isEmpty {
+            return mode == "dual" || mode == "per_device"
+        }
+        if let legacy = object["per_device_wrapping"] as? Bool {
+            return legacy
+        }
+        return false
+    }
+
+    /// Inline the active per-device recipients and THIS device's age secret into
+    /// the Keychain config copy so the sandboxed FileProvider can build a
+    /// device-aware EncryptionContext without reading ~/.config/tcfs.
+    ///
+    /// The inlined keys are consumed by the Rust read-side
+    /// (`crates/tcfs-file-provider/src/device_ctx.rs`,
+    /// `resolve_recipients` / `resolve_device_identity`), which prefers them over
+    /// the on-disk registry/secret:
+    ///   - `device_recipients`: [{ "device_id", "recipient" }, ...] — active,
+    ///     non-revoked devices that carry a real age recipient.
+    ///   - `device_recipients_all_capable`: Bool — the host's roll-call result
+    ///     (every active device carries a real age recipient). Gates the
+    ///     PerDevice contract drop on the Rust side exactly like the daemon.
+    ///   - `device_secret`: String — this device's armored age secret
+    ///     (`device-<device_id>.age` contents).
+    ///
+    /// DRAFT / UNVERIFIED: this cannot be compiled or device-tested in the agent
+    /// sandbox; it needs a real-device Xcode build + FileProvider QA. The
+    /// registry here is read with NO signature verification (see B4 — the
+    /// DeviceRegistry is forgeable today); this code only mirrors the existing
+    /// trust posture and does NOT add a new trust boundary.
+    private static func enrichPerDeviceMaterial(_ object: inout [String: Any]) {
+        guard wrapModeIsPerDevice(object) else {
+            // wrap_mode=master (default): leave the config untouched.
+            return
+        }
+
+        // Resolve the registry path: explicit override, else default
+        // ~/.config/tcfs/devices.json.
+        let registryPath: String
+        if let explicit = object["device_registry_path"] as? String, !explicit.isEmpty {
+            registryPath = (explicit as NSString).expandingTildeInPath
+        } else {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            registryPath = home.appendingPathComponent(".config/tcfs/devices.json").path
+        }
+
+        let registryURL = URL(fileURLWithPath: registryPath)
+        guard let registryData = try? Data(contentsOf: registryURL),
+              let registryObject = try? JSONSerialization.jsonObject(with: registryData)
+              as? [String: Any],
+              let devices = registryObject["devices"] as? [[String: Any]]
+        else {
+            hostEvent("provisionConfig: device registry unreadable; skipping per-device inlining")
+            return
+        }
+
+        // Active (non-revoked) devices that carry a *real* age recipient. Mirrors
+        // the Rust `active_devices().filter(is_real_age_public_key)` and the
+        // roll-call gate (all_capable = no active device lacks a real recipient).
+        var recipients: [[String: String]] = []
+        var activeCount = 0
+        var capableCount = 0
+        for device in devices {
+            let revoked = (device["revoked"] as? Bool) ?? false
+            if revoked { continue }
+            activeCount += 1
+            guard let deviceId = device["device_id"] as? String, !deviceId.isEmpty,
+                  let publicKey = device["public_key"] as? String,
+                  isRealAgePublicKey(publicKey)
+            else {
+                continue
+            }
+            capableCount += 1
+            recipients.append(["device_id": deviceId, "recipient": publicKey])
+        }
+
+        guard !recipients.isEmpty else {
+            hostEvent("provisionConfig: no active age recipients; skipping per-device inlining")
+            return
+        }
+
+        object["device_recipients"] = recipients
+        // all_capable iff every active device carried a real recipient.
+        object["device_recipients_all_capable"] = (activeCount == capableCount)
+
+        // Inline THIS device's age secret (device-<device_id>.age), resolved
+        // relative to the registry directory — mirrors the Rust
+        // `device_secret_key_path(registry_path, device_id)` layout.
+        if let deviceId = object["device_id"] as? String, !deviceId.isEmpty {
+            let registryDir = registryURL.deletingLastPathComponent()
+            let secretURL = registryDir.appendingPathComponent("device-\(deviceId).age")
+            if let secretData = try? Data(contentsOf: secretURL),
+               let secret = String(data: secretData, encoding: .utf8) {
+                let trimmed = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    object["device_secret"] = trimmed
+                    hostEvent(
+                        "provisionConfig: inlined \(recipients.count) recipient(s) + device "
+                            + "secret for \(deviceId) (all_capable="
+                            + "\(activeCount == capableCount))"
+                    )
+                } else {
+                    hostEvent("provisionConfig: device secret file empty; recipients inlined only")
+                }
+            } else {
+                // Recipients inlined but no local secret — the Rust read-side then
+                // falls back to its fs read (which fails closed in-sandbox). We do
+                // NOT inline a partial/empty secret.
+                hostEvent("provisionConfig: device-\(deviceId).age unreadable; recipients only")
+            }
+        } else {
+            hostEvent("provisionConfig: no device_id in config; cannot inline device secret")
+        }
+    }
+
+    /// Approximate Swift mirror of `tcfs_secrets::device::is_real_age_public_key`,
+    /// which in Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has
+    /// no age crate here, so this only checks the `age1` prefix and a plausible
+    /// length — a deliberately conservative heuristic.
+    ///
+    /// SAFETY: the Rust read-side (`resolve_recipients`) RE-VALIDATES every
+    /// inlined recipient with the real `is_real_age_public_key`, so a Swift
+    /// false-positive cannot inject a malformed recipient into the wrap set. The
+    /// one Swift-only signal the Rust side trusts is
+    /// `device_recipients_all_capable`; a Swift over-count there could let the
+    /// Rust side enter PerDevice (drop the master wrap) prematurely. Hardening
+    /// this to a real bech32/age parse on the Swift side is a follow-up (needs an
+    /// age-Swift dependency); flagged for real-device review.
+    private static func isRealAgePublicKey(_ publicKey: String) -> Bool {
+        let trimmed = publicKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        // age1 + bech32 payload; real keys are ~62 chars. Require a healthy
+        // minimum to reject obvious placeholders without over-trusting.
+        return trimmed.hasPrefix("age1") && trimmed.count >= 50
     }
 
     private static func serializeConfigObject(

--- a/swift/fileprovider/Sources/HostApp/HostApp.swift
+++ b/swift/fileprovider/Sources/HostApp/HostApp.swift
@@ -526,24 +526,142 @@ struct TCFSProviderApp {
         }
     }
 
-    /// Approximate Swift mirror of `tcfs_secrets::device::is_real_age_public_key`,
-    /// which in Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has
-    /// no age crate here, so this only checks the `age1` prefix and a plausible
-    /// length — a deliberately conservative heuristic.
+    /// Swift mirror of `tcfs_secrets::device::is_real_age_public_key`, which in
+    /// Rust does a FULL `age::x25519::Recipient` bech32 parse. Swift has no age
+    /// crate here, so this performs a real bech32 decode in pure Swift —
+    /// validating the `age` human-readable part, the bech32 charset, the BCH
+    /// checksum, and that the decoded payload is exactly the 32-byte X25519
+    /// public key an age recipient carries — instead of a prefix/length
+    /// heuristic. An age v1 recipient is `bech32("age", x25519_pubkey[32])`.
     ///
-    /// SAFETY: the Rust read-side (`resolve_recipients`) RE-VALIDATES every
-    /// inlined recipient with the real `is_real_age_public_key`, so a Swift
-    /// false-positive cannot inject a malformed recipient into the wrap set. The
-    /// one Swift-only signal the Rust side trusts is
-    /// `device_recipients_all_capable`; a Swift over-count there could let the
-    /// Rust side enter PerDevice (drop the master wrap) prematurely. Hardening
-    /// this to a real bech32/age parse on the Swift side is a follow-up (needs an
-    /// age-Swift dependency); flagged for real-device review.
+    /// DEFENSE IN DEPTH (this is one of two layers — neither is solely trusted):
+    ///   1. The Rust read-side (`resolve_recipients`) RE-VALIDATES every inlined
+    ///      recipient with the real `is_real_age_public_key` and RE-DERIVES
+    ///      `all_capable` from its OWN re-validated set — it does NOT trust the
+    ///      host's `device_recipients_all_capable` boolean. So even a Swift
+    ///      false-positive here cannot inject a malformed recipient into the wrap
+    ///      set NOR force a premature PerDevice master-wrap drop (lockout).
+    ///   2. This bech32 decode tightens the host-side roll call so the inlined
+    ///      `device_recipients_all_capable` signal is accurate in the common
+    ///      case, reducing spurious Dual downgrades.
+    ///
+    /// NOTE: this still does not verify registry AUTHENTICITY (a forged registry
+    /// can carry a genuinely well-formed attacker recipient) — that is B4's
+    /// signed-registry job, out of scope here.
+    ///
+    /// DRAFT / UNVERIFIED: cannot be compiled or device-tested in the agent
+    /// sandbox; needs a real-device Xcode build + FileProvider QA. Do not claim
+    /// Swift build success.
     private static func isRealAgePublicKey(_ publicKey: String) -> Bool {
         let trimmed = publicKey.trimmingCharacters(in: .whitespacesAndNewlines)
-        // age1 + bech32 payload; real keys are ~62 chars. Require a healthy
-        // minimum to reject obvious placeholders without over-trusting.
-        return trimmed.hasPrefix("age1") && trimmed.count >= 50
+        guard let decoded = decodeBech32(trimmed), decoded.hrp == "age" else {
+            return false
+        }
+        // age v1 recipient payload is the raw 32-byte X25519 public key.
+        return decoded.data.count == 32
+    }
+
+    /// Minimal bech32 decoder (BIP-0173) sufficient to validate an age v1
+    /// recipient: lowercase-only, HRP separated by the last `1`, valid charset,
+    /// and a correct BCH checksum. Returns the human-readable part and the
+    /// 8-bit-regrouped data payload, or nil on any malformation. (age uses
+    /// classic bech32, not bech32m.)
+    private static func decodeBech32(_ input: String) -> (hrp: String, data: [UInt8])? {
+        // Reject mixed case (bech32 forbids it) and non-ASCII.
+        let lower = input.lowercased()
+        if lower != input && input.uppercased() != input {
+            return nil
+        }
+        let s = lower
+        guard s.count >= 8, s.count <= 1023, s.allSatisfy({ $0.isASCII }) else {
+            return nil
+        }
+        guard let sepIndex = s.lastIndex(of: "1") else { return nil }
+        let hrp = String(s[s.startIndex..<sepIndex])
+        let dataPart = String(s[s.index(after: sepIndex)...])
+        // HRP must be non-empty; data part must include the 6-char checksum.
+        guard !hrp.isEmpty, dataPart.count >= 6 else { return nil }
+        guard hrp.allSatisfy({ c in
+            guard let v = c.asciiValue else { return false }
+            return v >= 33 && v <= 126
+        }) else { return nil }
+
+        let charset = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+        var values: [UInt8] = []
+        values.reserveCapacity(dataPart.count)
+        for c in dataPart {
+            guard let idx = charset.firstIndex(of: c) else { return nil }
+            values.append(UInt8(idx))
+        }
+
+        guard bech32VerifyChecksum(hrp: hrp, values: values) else { return nil }
+
+        // Strip the 6-symbol checksum and regroup 5-bit -> 8-bit.
+        let payload5 = Array(values.dropLast(6))
+        guard let payload8 = convertBits(payload5, from: 5, to: 8, pad: false) else {
+            return nil
+        }
+        return (hrp, payload8)
+    }
+
+    private static func bech32HrpExpand(_ hrp: String) -> [UInt8] {
+        let bytes = Array(hrp.utf8)
+        var out: [UInt8] = []
+        out.reserveCapacity(bytes.count * 2 + 1)
+        for b in bytes { out.append(b >> 5) }
+        out.append(0)
+        for b in bytes { out.append(b & 31) }
+        return out
+    }
+
+    private static func bech32Polymod(_ values: [UInt8]) -> UInt32 {
+        let gen: [UInt32] = [0x3b6a_57b2, 0x2650_8e6d, 0x1ea1_19fa, 0x3d42_33dd, 0x2a14_62b3]
+        var chk: UInt32 = 1
+        for v in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ff_ffff) << 5) ^ UInt32(v)
+            for i in 0..<5 where ((top >> UInt32(i)) & 1) == 1 {
+                chk ^= gen[i]
+            }
+        }
+        return chk
+    }
+
+    private static func bech32VerifyChecksum(hrp: String, values: [UInt8]) -> Bool {
+        // Classic bech32 constant is 1 (bech32m would be 0x2bc830a3).
+        bech32Polymod(bech32HrpExpand(hrp) + values) == 1
+    }
+
+    /// Regroup a base-2^`from` array into base-2^`to`. Mirrors the reference
+    /// bech32 `convertbits`. With `pad: false` any leftover bits must be zero.
+    private static func convertBits(
+        _ data: [UInt8],
+        from: UInt32,
+        to: UInt32,
+        pad: Bool
+    ) -> [UInt8]? {
+        var acc: UInt32 = 0
+        var bits: UInt32 = 0
+        var out: [UInt8] = []
+        let maxv: UInt32 = (1 << to) - 1
+        for value in data {
+            let v = UInt32(value)
+            if (v >> from) != 0 { return nil }
+            acc = (acc << from) | v
+            bits += from
+            while bits >= to {
+                bits -= to
+                out.append(UInt8((acc >> bits) & maxv))
+            }
+        }
+        if pad {
+            if bits > 0 {
+                out.append(UInt8((acc << (to - bits)) & maxv))
+            }
+        } else if bits >= from || ((acc << (to - bits)) & maxv) != 0 {
+            return nil
+        }
+        return out
     }
 
     private static func serializeConfigObject(


### PR DESCRIPTION
Syncs `Jesssullivan/tummycrypt` `origin/main` (`c8a9714`) onto `tinyland-inc/main` (`cf886d9`), carrying this session's repo-roam + per-device-crypto work that the lab flake builds from.

## What comes over (23 commits origin had, tinyland lacked)
- **TIN-1417** per-device crypto substrate: tri-state `crypto.wrap_mode` (master|dual|per_device), B4 Ed25519-signed device registry, keychain inlining
- **TIN-1898** FileProvider Dual/v2 master-wrap read fallback
- **TIN-1899** scoped per-device `tcfs key rotate` (forward secrecy) + revoke UX
- **#501** `~/.claude/projects` roam-enrollment runbook
- **#505/#507/#508/#509** the repo-roam zero-diff ladder: git-roam acceptance + harness, dev-env fingerprint, **reconcile restore fidelity (mtime preserve + symlink convergence fix)**, fingerprint deny-set hardening
- **#500** cargo-deny advisory updates

## Conflict resolution (union — no coverage/feature dropped)
- **`deny.toml`** — identical advisory ID set on both sides (`RUSTSEC-2025-0141`, `-2026-0097`, `-2026-0173`); kept origin's comment prose. No advisory coverage changed.
- **`Taskfile.yaml`** (`lazy:check`) — UNION: keeps origin's `git-roam-daily-driver-harness` + `dev-env-fingerprint` tooling **and** tinyland's `test-bazel-macos-package-contract.sh`. Both script files are present in the merged tree; `task --list-all` parses.

Preserves all 41 tinyland-only Darwin/Bazel release-packaging commits (non-`.git` disjoint paths, no conflict). Non-destructive merge, no force-push.

This sync is the gate for bumping the lab `flake.lock` `tummycrypt` input (currently stale at `e53bc72`) to deploy the repo-roam fixes to neo+honey.
